### PR TITLE
Editor: Use Qt-5 signal/slot connections where applicable

### DIFF
--- a/Editor/ADSREditor.cpp
+++ b/Editor/ADSREditor.cpp
@@ -828,7 +828,7 @@ ADSRControls::ADSRControls(QWidget* parent) : QFrame(parent) {
   m_attack->setSingleStep(0.1);
   m_attack->setSuffix(tr(" sec"));
   m_attack->setPalette(palette);
-  connect(m_attack, SIGNAL(valueChanged(double)), this, SLOT(attackChanged(double)));
+  connect(m_attack, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &ADSRControls::attackChanged);
   leftLayout->addWidget(m_attack, 1, 0);
 
   palette.setColor(QPalette::Text, Green);
@@ -842,7 +842,7 @@ ADSRControls::ADSRControls(QWidget* parent) : QFrame(parent) {
   m_decay->setSingleStep(0.1);
   m_decay->setSuffix(tr(" sec"));
   m_decay->setPalette(palette);
-  connect(m_decay, SIGNAL(valueChanged(double)), this, SLOT(decayChanged(double)));
+  connect(m_decay, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &ADSRControls::decayChanged);
   leftLayout->addWidget(m_decay, 1, 1);
 
   palette.setColor(QPalette::Text, Qt::white);
@@ -853,7 +853,7 @@ ADSRControls::ADSRControls(QWidget* parent) : QFrame(parent) {
   m_sustain->setDecimals(3);
   m_sustain->setSuffix(tr(" %"));
   m_sustain->setPalette(palette);
-  connect(m_sustain, SIGNAL(valueChanged(double)), this, SLOT(sustainChanged(double)));
+  connect(m_sustain, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &ADSRControls::sustainChanged);
   leftLayout->addWidget(m_sustain, 1, 2);
 
   palette.setColor(QPalette::Text, Blue);
@@ -867,7 +867,7 @@ ADSRControls::ADSRControls(QWidget* parent) : QFrame(parent) {
   m_release->setSingleStep(0.1);
   m_release->setSuffix(tr(" sec"));
   m_release->setPalette(palette);
-  connect(m_release, SIGNAL(valueChanged(double)), this, SLOT(releaseChanged(double)));
+  connect(m_release, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &ADSRControls::releaseChanged);
   leftLayout->addWidget(m_release, 1, 3);
 
   palette.setColor(QPalette::Text, Qt::white);
@@ -876,7 +876,7 @@ ADSRControls::ADSRControls(QWidget* parent) : QFrame(parent) {
   m_dls->setPalette(palette);
   m_dls->setDisabled(true);
   m_dls->setChecked(false);
-  connect(m_dls, SIGNAL(stateChanged(int)), this, SLOT(dlsStateChanged(int)));
+  connect(m_dls, qOverload<int>(&QCheckBox::stateChanged), this, &ADSRControls::dlsStateChanged);
   leftLayout->addWidget(m_dls, 1, 4);
 
   m_velToAttackLab = new QLabel(tr("Vel To Attack"));
@@ -888,7 +888,7 @@ ADSRControls::ADSRControls(QWidget* parent) : QFrame(parent) {
   m_velToAttack->setDecimals(3);
   m_velToAttack->setSingleStep(1.0);
   m_velToAttack->setPalette(palette);
-  connect(m_velToAttack, SIGNAL(valueChanged(double)), this, SLOT(velToAttackChanged(double)));
+  connect(m_velToAttack, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &ADSRControls::velToAttackChanged);
   leftLayout->addWidget(m_velToAttack, 1, 5);
 
   m_keyToDecayLab = new QLabel(tr("Key To Decay"));
@@ -900,7 +900,7 @@ ADSRControls::ADSRControls(QWidget* parent) : QFrame(parent) {
   m_keyToDecay->setDecimals(3);
   m_keyToDecay->setSingleStep(1.0);
   m_keyToDecay->setPalette(palette);
-  connect(m_keyToDecay, SIGNAL(valueChanged(double)), this, SLOT(keyToDecayChanged(double)));
+  connect(m_keyToDecay, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &ADSRControls::keyToDecayChanged);
   leftLayout->addWidget(m_keyToDecay, 1, 6);
 
   leftLayout->setColumnMinimumWidth(0, 75);

--- a/Editor/CurveEditor.cpp
+++ b/Editor/CurveEditor.cpp
@@ -206,12 +206,12 @@ CurveControls::CurveControls(QWidget* parent) : QFrame(parent) {
   QPalette palette = m_lineEdit->palette();
   palette.setColor(QPalette::Base, palette.color(QPalette::Window));
   m_lineEdit->setPalette(palette);
-  connect(m_lineEdit, SIGNAL(returnPressed()), this, SLOT(exprCommit()));
+  connect(m_lineEdit, &QLineEdit::returnPressed, this, &CurveControls::exprCommit);
   leftLayout->addWidget(m_lineEdit, 1, 0);
 
   m_setExpr = new QPushButton(tr("Apply"));
   m_setExpr->setDisabled(true);
-  connect(m_setExpr, SIGNAL(clicked(bool)), this, SLOT(exprCommit()));
+  connect(m_setExpr, &QPushButton::clicked, this, &CurveControls::exprCommit);
   leftLayout->addWidget(m_setExpr, 1, 1);
 
   m_errLabel = new QLabel(this);

--- a/Editor/EditorWidget.cpp
+++ b/Editor/EditorWidget.cpp
@@ -18,7 +18,7 @@ FieldSlider::FieldSlider(QWidget* parent) : QWidget(parent), m_slider(Qt::Horizo
   layout->setContentsMargins(QMargins());
   setLayout(layout);
   m_value.setFixedWidth(42);
-  connect(&m_slider, SIGNAL(valueChanged(int)), this, SLOT(doValueChanged(int)));
+  connect(&m_slider, qOverload<int>(&QSlider::valueChanged), this, &FieldSlider::doValueChanged);
   m_slider.setValue(0);
 }
 
@@ -36,7 +36,7 @@ FieldDoubleSlider::FieldDoubleSlider(QWidget* parent) : QWidget(parent), m_slide
   layout->setContentsMargins(QMargins());
   setLayout(layout);
   m_value.setFixedWidth(42);
-  connect(&m_slider, SIGNAL(valueChanged(int)), this, SLOT(doValueChanged(int)));
+  connect(&m_slider, qOverload<int>(&QSlider::valueChanged), this, &FieldDoubleSlider::doValueChanged);
   m_slider.setRange(0, 1000);
   m_slider.setValue(0);
 }
@@ -77,8 +77,9 @@ FieldProjectNode::FieldProjectNode(ProjectModel::CollectionNode* collection, QWi
   m_button.setDisabled(true);
   m_button.setFixedSize(30, 30);
   m_comboBox.setFixedHeight(30);
-  connect(&m_comboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(_currentIndexChanged(int)));
-  connect(&m_button, SIGNAL(clicked(bool)), this, SLOT(openCurrent()));
+  connect(&m_comboBox, qOverload<int>(&FieldComboBox::currentIndexChanged), this,
+          &FieldProjectNode::_currentIndexChanged);
+  connect(&m_button, &QPushButton::clicked, this, &FieldProjectNode::openCurrent);
   QIcon icon(QStringLiteral(":/icons/IconForward.svg"));
   icon.addFile(QStringLiteral(":/icons/IconForwardDisabled.svg"), {}, QIcon::Disabled);
   m_button.setIcon(icon);
@@ -137,8 +138,9 @@ FieldPageObjectNode::FieldPageObjectNode(ProjectModel::GroupNode* group, QWidget
   m_button.setDisabled(true);
   m_button.setFixedSize(30, 30);
   m_comboBox.setFixedHeight(30);
-  connect(&m_comboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(_currentIndexChanged(int)));
-  connect(&m_button, SIGNAL(clicked(bool)), this, SLOT(openCurrent()));
+  connect(&m_comboBox, qOverload<int>(&FieldComboBox::currentIndexChanged), this,
+          &FieldPageObjectNode::_currentIndexChanged);
+  connect(&m_button, &QPushButton::clicked, this, &FieldPageObjectNode::openCurrent);
   QIcon icon(QStringLiteral(":/icons/IconForward.svg"));
   icon.addFile(QStringLiteral(":/icons/IconForwardDisabled.svg"), {}, QIcon::Disabled);
   m_button.setIcon(icon);
@@ -247,13 +249,13 @@ bool BaseObjectDelegate::editorEvent(QEvent* event, QAbstractItemModel* model, c
       QAction* openEditorAction = new QAction(tr("Open in Editor"), menu);
       openEditorAction->setData(QVariant::fromValue((void*)node));
       openEditorAction->setIcon(QIcon::fromTheme(QStringLiteral("document-edit")));
-      connect(openEditorAction, SIGNAL(triggered()), this, SLOT(doOpenEditor()));
+      connect(openEditorAction, &QAction::triggered, this, &BaseObjectDelegate::doOpenEditor);
       menu->addAction(openEditorAction);
 
       QAction* findUsagesAction = new QAction(tr("Find Usages"), menu);
       findUsagesAction->setData(QVariant::fromValue((void*)node));
       findUsagesAction->setIcon(QIcon::fromTheme(QStringLiteral("edit-find")));
-      connect(findUsagesAction, SIGNAL(triggered()), this, SLOT(doFindUsages()));
+      connect(findUsagesAction, &QAction::triggered, this, &BaseObjectDelegate::doFindUsages);
       menu->addAction(findUsagesAction);
 
       menu->popup(ev->globalPos());

--- a/Editor/KeymapEditor.cpp
+++ b/Editor/KeymapEditor.cpp
@@ -250,7 +250,7 @@ KeymapControls::KeymapControls(QWidget* parent) : QFrame(parent) {
   leftLayout->addWidget(new QLabel(tr("SoundMacro")), 0, 0);
   m_macro = new FieldProjectNode;
   m_macro->setDisabled(true);
-  connect(m_macro, SIGNAL(currentIndexChanged(int)), this, SLOT(controlChanged()));
+  connect(m_macro, qOverload<int>(&FieldProjectNode::currentIndexChanged), this, &KeymapControls::controlChanged);
   leftLayout->addWidget(m_macro, 1, 0);
 
   leftLayout->addWidget(new QLabel(tr("Transpose")), 0, 1);
@@ -259,7 +259,7 @@ KeymapControls::KeymapControls(QWidget* parent) : QFrame(parent) {
   m_transpose->setDisabled(true);
   m_transpose->setRange(-128, 127);
   m_transpose->setToolTip(tr("Offset resulting MIDI note"));
-  connect(m_transpose, SIGNAL(valueChanged(int)), this, SLOT(controlChanged()));
+  connect(m_transpose, qOverload<int>(&QSpinBox::valueChanged), this, &KeymapControls::controlChanged);
   leftLayout->addWidget(m_transpose, 1, 1);
 
   leftLayout->addWidget(new QLabel(tr("Pan")), 0, 2);
@@ -268,7 +268,7 @@ KeymapControls::KeymapControls(QWidget* parent) : QFrame(parent) {
   m_pan->setDisabled(true);
   m_pan->setRange(-127, 127);
   m_pan->setToolTip(tr("Set initial pan"));
-  connect(m_pan, SIGNAL(valueChanged(int)), this, SLOT(controlChanged()));
+  connect(m_pan, qOverload<int>(&QSpinBox::valueChanged), this, &KeymapControls::controlChanged);
   leftLayout->addWidget(m_pan, 1, 2);
 
   leftLayout->addWidget(new QLabel(tr("Surround")), 0, 3);
@@ -276,7 +276,7 @@ KeymapControls::KeymapControls(QWidget* parent) : QFrame(parent) {
   m_surround->setPalette(palette);
   m_surround->setDisabled(true);
   m_surround->setToolTip(tr("Initially play through surround channels"));
-  connect(m_surround, SIGNAL(stateChanged(int)), this, SLOT(controlChanged()));
+  connect(m_surround, qOverload<int>(&QCheckBox::stateChanged), this, &KeymapControls::controlChanged);
   leftLayout->addWidget(m_surround, 1, 3);
 
   leftLayout->addWidget(new QLabel(tr("Prio Offset")), 0, 4);
@@ -285,7 +285,7 @@ KeymapControls::KeymapControls(QWidget* parent) : QFrame(parent) {
   m_prioOffset->setDisabled(true);
   m_prioOffset->setRange(-128, 127);
   m_prioOffset->setToolTip(tr("Offset resulting priority"));
-  connect(m_prioOffset, SIGNAL(valueChanged(int)), this, SLOT(controlChanged()));
+  connect(m_prioOffset, qOverload<int>(&QSpinBox::valueChanged), this, &KeymapControls::controlChanged);
   leftLayout->addWidget(m_prioOffset, 1, 4);
 
   leftLayout->setColumnMinimumWidth(0, 200);
@@ -301,7 +301,7 @@ KeymapControls::KeymapControls(QWidget* parent) : QFrame(parent) {
 
   m_paintButton = new PaintButton;
   m_paintButton->setDisabled(true);
-  connect(m_paintButton, SIGNAL(pressed()), this, SLOT(paintButtonPressed()));
+  connect(m_paintButton, &PaintButton::pressed, this, &KeymapControls::paintButtonPressed);
   rightLayout->addWidget(m_paintButton);
   rightLayout->setContentsMargins(0, 0, 10, 0);
 

--- a/Editor/LayersEditor.cpp
+++ b/Editor/LayersEditor.cpp
@@ -109,7 +109,7 @@ QWidget* SoundMacroDelegate::createEditor(QWidget* parent, const QStyleOptionVie
   ProjectModel::GroupNode* group = g_MainWindow->projectModel()->getGroupNode(model->m_node.get());
   EditorFieldProjectNode* cb =
       new EditorFieldProjectNode(group->getCollectionOfType(ProjectModel::INode::Type::SoundMacro), parent);
-  connect(cb, SIGNAL(currentIndexChanged(int)), this, SLOT(smIndexChanged()));
+  connect(cb, qOverload<int>(&EditorFieldProjectNode::currentIndexChanged), this, &SoundMacroDelegate::smIndexChanged);
   return cb;
 }
 
@@ -606,15 +606,13 @@ void LayersEditor::itemDeleteAction() { m_tableView.deleteSelection(); }
 LayersEditor::LayersEditor(QWidget* parent)
 : EditorWidget(parent), m_model(this), m_tableView(this), m_addRemoveButtons(this) {
   m_tableView.setModel(&m_model);
-  connect(m_tableView.selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this,
-          SLOT(doSelectionChanged()));
-  connect(&m_model, SIGNAL(rowsInserted(const QModelIndex&, int, int)), this,
-          SLOT(rowsInserted(const QModelIndex&, int, int)));
-  connect(&m_model, SIGNAL(rowsMoved(const QModelIndex&, int, int, const QModelIndex&, int)), this,
-          SLOT(rowsMoved(const QModelIndex&, int, int, const QModelIndex&, int)));
+  connect(m_tableView.selectionModel(), &QItemSelectionModel::selectionChanged, this,
+          &LayersEditor::doSelectionChanged);
+  connect(&m_model, &LayersModel::rowsInserted, this, &LayersEditor::rowsInserted);
+  connect(&m_model, &LayersModel::rowsMoved, this, &LayersEditor::rowsMoved);
 
   m_addRemoveButtons.addAction()->setToolTip(tr("Add new layer mapping"));
-  connect(m_addRemoveButtons.addAction(), SIGNAL(triggered(bool)), this, SLOT(doAdd()));
+  connect(m_addRemoveButtons.addAction(), &QAction::triggered, this, &LayersEditor::doAdd);
   m_addRemoveButtons.removeAction()->setToolTip(tr("Remove selected layer mappings"));
-  connect(m_addRemoveButtons.removeAction(), SIGNAL(triggered(bool)), this, SLOT(itemDeleteAction()));
+  connect(m_addRemoveButtons.removeAction(), &QAction::triggered, this, &LayersEditor::itemDeleteAction);
 }

--- a/Editor/MainWindow.cpp
+++ b/Editor/MainWindow.cpp
@@ -50,68 +50,67 @@ MainWindow::MainWindow(QWidget* parent)
   palette.setColor(QPalette::Base, palette.color(QPalette::Window));
   m_ui.projectOutlineFilter->setPalette(palette);
   m_ui.projectOutline->setItemDelegate(&m_treeDelegate);
-  connect(m_ui.projectOutline, SIGNAL(activated(const QModelIndex&)), this,
-          SLOT(outlineItemActivated(const QModelIndex&)));
+  connect(m_ui.projectOutline, &QTreeView::activated, this, &MainWindow::outlineItemActivated);
   m_goBack = new QAction(m_ui.backButton->icon(), tr("Go Back"), this);
   m_goBack->setEnabled(false);
-  connect(m_goBack, SIGNAL(triggered()), this, SLOT(goBack()));
+  connect(m_goBack, &QAction::triggered, this, &MainWindow::goBack);
   m_goBack->setShortcut(QKeySequence::Back);
   m_ui.backButton->setDefaultAction(m_goBack);
   m_goForward = new QAction(m_ui.forwardButton->icon(), tr("Go Forward"), this);
   m_goForward->setEnabled(false);
-  connect(m_goForward, SIGNAL(triggered()), this, SLOT(goForward()));
+  connect(m_goForward, &QAction::triggered, this, &MainWindow::goForward);
   m_goForward->setShortcut(QKeySequence::Forward);
   m_ui.forwardButton->setDefaultAction(m_goForward);
 
   connectMessenger(&m_mainMessenger, Qt::DirectConnection);
 
-  m_ui.statusbar->connectKillClicked(this, SLOT(killSounds()));
-  m_ui.statusbar->connectFXPressed(this, SLOT(fxPressed()));
+  m_ui.statusbar->connectKillClicked(this, &MainWindow::killSounds);
+  m_ui.statusbar->connectFXPressed(this, &MainWindow::fxPressed);
   m_ui.statusbar->setVolumeValue(70);
-  m_ui.statusbar->connectVolumeSlider(this, SLOT(volumeChanged(int)));
-  m_ui.statusbar->connectASlider(this, SLOT(auxAChanged(int)));
-  m_ui.statusbar->connectBSlider(this, SLOT(auxBChanged(int)));
+  m_ui.statusbar->connectVolumeSlider(this, &MainWindow::volumeChanged);
+  m_ui.statusbar->connectASlider(this, &MainWindow::auxAChanged);
+  m_ui.statusbar->connectBSlider(this, &MainWindow::auxBChanged);
 
   m_ui.keyboardContents->setStatusFocus(new StatusBarFocus(m_ui.statusbar));
   m_ui.velocitySlider->setStatusFocus(new StatusBarFocus(m_ui.statusbar));
   m_ui.modulationSlider->setStatusFocus(new StatusBarFocus(m_ui.statusbar));
   m_ui.pitchSlider->setStatusFocus(new StatusBarFocus(m_ui.statusbar));
-  connect(m_ui.keyboardContents, SIGNAL(notePressed(int)), this, SLOT(notePressed(int)));
-  connect(m_ui.keyboardContents, SIGNAL(noteReleased()), this, SLOT(noteReleased()));
-  connect(m_ui.velocitySlider, SIGNAL(valueChanged(int)), this, SLOT(velocityChanged(int)));
-  connect(m_ui.modulationSlider, SIGNAL(valueChanged(int)), this, SLOT(modulationChanged(int)));
-  connect(m_ui.pitchSlider, SIGNAL(valueChanged(int)), this, SLOT(pitchChanged(int)));
+  connect(m_ui.keyboardContents, &KeyboardWidget::notePressed, this, &MainWindow::notePressed);
+  connect(m_ui.keyboardContents, &KeyboardWidget::noteReleased, this, &MainWindow::noteReleased);
+  connect(m_ui.velocitySlider, qOverload<int>(&VelocitySlider::valueChanged), this, &MainWindow::velocityChanged);
+  connect(m_ui.modulationSlider, qOverload<int>(&ModulationSlider::valueChanged), this, &MainWindow::modulationChanged);
+  connect(m_ui.pitchSlider, qOverload<int>(&PitchSlider::valueChanged), this, &MainWindow::pitchChanged);
 
   m_ui.actionNew_Project->setShortcut(QKeySequence::New);
-  connect(m_ui.actionNew_Project, SIGNAL(triggered()), this, SLOT(newAction()));
+  connect(m_ui.actionNew_Project, &QAction::triggered, this, &MainWindow::newAction);
   m_ui.actionOpen_Project->setShortcut(QKeySequence::Open);
-  connect(m_ui.actionOpen_Project, SIGNAL(triggered()), this, SLOT(openAction()));
+  connect(m_ui.actionOpen_Project, &QAction::triggered, this, &MainWindow::openAction);
   m_ui.actionSave_Project->setShortcut(QKeySequence::Save);
-  connect(m_ui.actionSave_Project, SIGNAL(triggered()), this, SLOT(saveAction()));
-  connect(m_ui.actionRevert_Project, SIGNAL(triggered()), this, SLOT(revertAction()));
-  connect(m_ui.actionReload_Sample_Data, SIGNAL(triggered()), this, SLOT(reloadSampleDataAction()));
-  connect(m_ui.actionImport_Groups, SIGNAL(triggered()), this, SLOT(importAction()));
-  connect(m_ui.actionImport_Songs, SIGNAL(triggered()), this, SLOT(importSongsAction()));
-  connect(m_ui.actionExport_GameCube_Groups, SIGNAL(triggered()), this, SLOT(exportAction()));
-  connect(m_ui.actionImport_C_Headers, SIGNAL(triggered()), this, SLOT(importHeadersAction()));
-  connect(m_ui.actionExport_C_Headers, SIGNAL(triggered()), this, SLOT(exportHeadersAction()));
+  connect(m_ui.actionSave_Project, &QAction::triggered, this, &MainWindow::saveAction);
+  connect(m_ui.actionRevert_Project, &QAction::triggered, this, &MainWindow::revertAction);
+  connect(m_ui.actionReload_Sample_Data, &QAction::triggered, this, &MainWindow::reloadSampleDataAction);
+  connect(m_ui.actionImport_Groups, &QAction::triggered, this, &MainWindow::importAction);
+  connect(m_ui.actionImport_Songs, &QAction::triggered, this, &MainWindow::importSongsAction);
+  connect(m_ui.actionExport_GameCube_Groups, &QAction::triggered, this, &MainWindow::exportAction);
+  connect(m_ui.actionImport_C_Headers, &QAction::triggered, this, &MainWindow::importHeadersAction);
+  connect(m_ui.actionExport_C_Headers, &QAction::triggered, this, &MainWindow::exportHeadersAction);
   m_ui.actionQuit->setShortcut(QKeySequence::Quit);
-  connect(m_ui.actionQuit, SIGNAL(triggered()), this, SLOT(close()));
+  connect(m_ui.actionQuit, &QAction::triggered, this, &MainWindow::close);
 
   for (int i = 0; i < MaxRecentFiles; ++i) {
     m_recentFileActs[i] = new QAction(this);
     m_recentFileActs[i]->setVisible(false);
     m_ui.menuRecent_Projects->addAction(m_recentFileActs[i]);
-    connect(m_recentFileActs[i], SIGNAL(triggered()), this, SLOT(openRecentFileAction()));
+    connect(m_recentFileActs[i], &QAction::triggered, this, &MainWindow::openRecentFileAction);
   }
   m_ui.menuRecent_Projects->addSeparator();
   m_clearRecentFileAct = new QAction(tr("Clear Recent Projects"), this);
-  connect(m_clearRecentFileAct, SIGNAL(triggered()), this, SLOT(clearRecentFilesAction()));
+  connect(m_clearRecentFileAct, &QAction::triggered, this, &MainWindow::clearRecentFilesAction);
   m_ui.menuRecent_Projects->addAction(m_clearRecentFileAct);
 
   updateRecentFileActions();
 
-  connect(m_undoStack, SIGNAL(cleanChanged(bool)), this, SLOT(cleanChanged(bool)));
+  connect(m_undoStack, &QUndoStack::cleanChanged, this, &MainWindow::cleanChanged);
   QAction* undoAction = m_undoStack->createUndoAction(this);
   undoAction->setShortcut(QKeySequence::Undo);
   undoAction->setIcon(QIcon::fromTheme(QStringLiteral("edit-undo")));
@@ -127,8 +126,8 @@ MainWindow::MainWindow(QWidget* parent)
   m_ui.actionDelete->setShortcut(QKeySequence::Delete);
   onFocusChanged(nullptr, this);
 
-  connect(m_ui.actionAbout_Amuse, SIGNAL(triggered()), this, SLOT(aboutAmuseAction()));
-  connect(m_ui.actionAbout_Qt, SIGNAL(triggered()), this, SLOT(aboutQtAction()));
+  connect(m_ui.actionAbout_Amuse, &QAction::triggered, this, &MainWindow::aboutAmuseAction);
+  connect(m_ui.actionAbout_Qt, &QAction::triggered, this, &MainWindow::aboutQtAction);
 
   QGridLayout* faceLayout = new QGridLayout;
   QSvgWidget* faceSvg = new QSvgWidget(QStringLiteral(":/bg/FaceGrey.svg"));
@@ -157,23 +156,23 @@ MainWindow::MainWindow(QWidget* parent)
   m_ui.editorContents->setCurrentWidget(m_faceSvg);
 
   m_studioSetup = new StudioSetupWidget(this);
-  connect(m_studioSetup, SIGNAL(hidden()), this, SLOT(studioSetupHidden()));
-  connect(m_studioSetup, SIGNAL(shown()), this, SLOT(studioSetupShown()));
+  connect(m_studioSetup, &StudioSetupWidget::hidden, this, &MainWindow::studioSetupHidden);
+  connect(m_studioSetup, &StudioSetupWidget::shown, this, &MainWindow::studioSetupShown);
 
-  connect(m_ui.actionNew_Subproject, SIGNAL(triggered()), this, SLOT(newSubprojectAction()));
-  connect(m_ui.actionNew_SFX_Group, SIGNAL(triggered()), this, SLOT(newSFXGroupAction()));
-  connect(m_ui.actionNew_Song_Group, SIGNAL(triggered()), this, SLOT(newSongGroupAction()));
-  connect(m_ui.actionNew_Sound_Macro, SIGNAL(triggered()), this, SLOT(newSoundMacroAction()));
-  connect(m_ui.actionNew_ADSR, SIGNAL(triggered()), this, SLOT(newADSRAction()));
-  connect(m_ui.actionNew_Curve, SIGNAL(triggered()), this, SLOT(newCurveAction()));
-  connect(m_ui.actionNew_Keymap, SIGNAL(triggered()), this, SLOT(newKeymapAction()));
-  connect(m_ui.actionNew_Layers, SIGNAL(triggered()), this, SLOT(newLayersAction()));
+  connect(m_ui.actionNew_Subproject, &QAction::triggered, this, &MainWindow::newSubprojectAction);
+  connect(m_ui.actionNew_SFX_Group, &QAction::triggered, this, &MainWindow::newSFXGroupAction);
+  connect(m_ui.actionNew_Song_Group, &QAction::triggered, this, &MainWindow::newSongGroupAction);
+  connect(m_ui.actionNew_Sound_Macro, &QAction::triggered, this, &MainWindow::newSoundMacroAction);
+  connect(m_ui.actionNew_ADSR, &QAction::triggered, this, &MainWindow::newADSRAction);
+  connect(m_ui.actionNew_Curve, &QAction::triggered, this, &MainWindow::newCurveAction);
+  connect(m_ui.actionNew_Keymap, &QAction::triggered, this, &MainWindow::newKeymapAction);
+  connect(m_ui.actionNew_Layers, &QAction::triggered, this, &MainWindow::newLayersAction);
 
-  connect(m_ui.menuAudio, SIGNAL(aboutToShow()), this, SLOT(aboutToShowAudioIOMenu()));
-  connect(m_ui.menuMIDI, SIGNAL(aboutToShow()), this, SLOT(aboutToShowMIDIIOMenu()));
+  connect(m_ui.menuAudio, &QMenu::aboutToShow, this, &MainWindow::aboutToShowAudioIOMenu);
+  connect(m_ui.menuMIDI, &QMenu::aboutToShow, this, &MainWindow::aboutToShowMIDIIOMenu);
 
-  connect(qApp, SIGNAL(focusChanged(QWidget*, QWidget*)), this, SLOT(onFocusChanged(QWidget*, QWidget*)));
-  connect(QGuiApplication::clipboard(), SIGNAL(dataChanged()), this, SLOT(onClipboardChanged()));
+  connect(qApp, &QApplication::focusChanged, this, &MainWindow::onFocusChanged);
+  connect(QGuiApplication::clipboard(), &QClipboard::dataChanged, this, &MainWindow::onClipboardChanged);
 
   m_voxEngine = boo::NewAudioVoiceEngine();
   m_voxAllocator = std::make_unique<VoiceAllocator>(*m_voxEngine);
@@ -194,31 +193,40 @@ MainWindow::~MainWindow() {
 }
 
 void MainWindow::connectMessenger(UIMessenger* messenger, Qt::ConnectionType type) {
-  connect(
-      messenger,
-      SIGNAL(information(const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton)),
-      this,
-      SLOT(msgInformation(const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton)),
-      type);
   connect(messenger,
-          SIGNAL(question(const QString&, const QString&, const QString&, const QString&, const QString&, int, int)),
+          qOverload<const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton>(
+              &UIMessenger::information),
           this,
-          SLOT(msgQuestion(const QString&, const QString&, const QString&, const QString&, const QString&, int, int)),
+          qOverload<const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton>(
+              &MainWindow::msgInformation),
           type);
   connect(messenger,
-          SIGNAL(question(const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton)),
+          qOverload<const QString&, const QString&, const QString&, const QString&, const QString&, int, int>(
+              &UIMessenger::question),
           this,
-          SLOT(msgQuestion(const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton)),
+          qOverload<const QString&, const QString&, const QString&, const QString&, const QString&, int, int>(
+              &MainWindow::msgQuestion),
           type);
   connect(messenger,
-          SIGNAL(warning(const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton)),
+          qOverload<const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton>(
+              &UIMessenger::question),
           this,
-          SLOT(msgWarning(const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton)),
+          qOverload<const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton>(
+              &MainWindow::msgQuestion),
           type);
   connect(messenger,
-          SIGNAL(critical(const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton)),
+          qOverload<const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton>(
+              &UIMessenger::warning),
           this,
-          SLOT(msgCritical(const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton)),
+          qOverload<const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton>(
+              &MainWindow::msgWarning),
+          type);
+  connect(messenger,
+          qOverload<const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton>(
+              &UIMessenger::critical),
+          this,
+          qOverload<const QString&, const QString&, QMessageBox::StandardButtons, QMessageBox::StandardButton>(
+              &MainWindow::msgCritical),
           type);
 }
 
@@ -288,11 +296,11 @@ bool MainWindow::setProjectPath(const QString& path) {
     m_projectModel->deleteLater();
   m_projectModel = new ProjectModel(path, this);
   m_ui.projectOutlineFilter->clear();
-  connect(m_ui.projectOutlineFilter, SIGNAL(textChanged(const QString&)), m_projectModel->getOutlineProxy(),
-          SLOT(setFilterRegExp(const QString&)));
+  connect(m_ui.projectOutlineFilter, &QLineEdit::textChanged, m_projectModel->getOutlineProxy(),
+          &OutlineFilterProxyModel::setFilterRegExp);
   m_ui.projectOutline->setModel(m_projectModel->getOutlineProxy());
-  connect(m_ui.projectOutline->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)),
-          this, SLOT(onOutlineSelectionChanged(const QItemSelection&, const QItemSelection&)));
+  connect(m_ui.projectOutline->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+          &MainWindow::onOutlineSelectionChanged);
   m_openDirectoryDialog.setDirectory(path);
   m_openFileDialog.setDirectory(path);
   m_newFileDialog.setDirectory(path);
@@ -342,7 +350,7 @@ void MainWindow::refreshAudioIO() {
       act->setData(QString::fromStdString(dev.first));
       if (curOut == dev.first)
         act->setChecked(true);
-      connect(act, SIGNAL(triggered()), this, SLOT(setAudioIO()));
+      connect(act, &QAction::triggered, this, &MainWindow::setAudioIO);
       addedDev = true;
     }
   }
@@ -364,7 +372,7 @@ void MainWindow::refreshMIDIIO() {
       act->setCheckable(true);
       act->setData(QStringLiteral("<amuse-virtual-in>"));
       act->setChecked(static_cast<MIDIReader*>(m_engine->getMIDIReader())->hasVirtualIn());
-      connect(act, SIGNAL(triggered(bool)), this, SLOT(setMIDIIO(bool)));
+      connect(act, &QAction::triggered, this, &MainWindow::setMIDIIO);
       addedDev = true;
     }
     for (const auto& dev : m_voxEngine->enumerateMIDIInputs()) {
@@ -372,7 +380,7 @@ void MainWindow::refreshMIDIIO() {
       act->setCheckable(true);
       act->setData(QString::fromStdString(dev.first));
       act->setChecked(static_cast<MIDIReader*>(m_engine->getMIDIReader())->hasMIDIIn(dev.first.c_str()));
-      connect(act, SIGNAL(triggered(bool)), this, SLOT(setMIDIIO(bool)));
+      connect(act, &QAction::triggered, this, &MainWindow::setMIDIIO);
       addedDev = true;
     }
   }
@@ -480,12 +488,16 @@ void MainWindow::startBackgroundTask(int id, const QString& windowTitle, const Q
   m_backgroundDialog->setMaximum(0);
   m_backgroundDialog->setValue(0);
 
-  connect(m_backgroundTask, SIGNAL(setMinimum(int)), m_backgroundDialog, SLOT(setMinimum(int)), Qt::QueuedConnection);
-  connect(m_backgroundTask, SIGNAL(setMaximum(int)), m_backgroundDialog, SLOT(setMaximum(int)), Qt::QueuedConnection);
-  connect(m_backgroundTask, SIGNAL(setValue(int)), m_backgroundDialog, SLOT(setValue(int)), Qt::QueuedConnection);
-  connect(m_backgroundTask, SIGNAL(setLabelText(const QString&)), m_backgroundDialog,
-          SLOT(setLabelText(const QString&)), Qt::QueuedConnection);
-  connect(m_backgroundTask, SIGNAL(finished(int)), this, SLOT(onBackgroundTaskFinished(int)), Qt::QueuedConnection);
+  connect(m_backgroundTask, &BackgroundTask::setMinimum, m_backgroundDialog, &QProgressDialog::setMinimum,
+          Qt::QueuedConnection);
+  connect(m_backgroundTask, &BackgroundTask::setMaximum, m_backgroundDialog, &QProgressDialog::setMaximum,
+          Qt::QueuedConnection);
+  connect(m_backgroundTask, &BackgroundTask::setValue, m_backgroundDialog, &QProgressDialog::setValue,
+          Qt::QueuedConnection);
+  connect(m_backgroundTask, &BackgroundTask::setLabelText, m_backgroundDialog, &QProgressDialog::setLabelText,
+          Qt::QueuedConnection);
+  connect(m_backgroundTask, &BackgroundTask::finished, this, &MainWindow::onBackgroundTaskFinished,
+          Qt::QueuedConnection);
   m_backgroundDialog->open(m_backgroundTask, SLOT(cancel()));
 
   connectMessenger(&m_backgroundTask->uiMessenger(), Qt::BlockingQueuedConnection);
@@ -1105,7 +1117,7 @@ bool TreeDelegate::editorEvent(QEvent* event, QAbstractItemModel* __model, const
       if (node->type() == ProjectModel::INode::Type::Group) {
         QAction* exportGroupAction = new QAction(tr("Export GameCube Group"), menu);
         exportGroupAction->setData(QVariant::fromValue((void*)node));
-        connect(exportGroupAction, SIGNAL(triggered()), this, SLOT(doExportGroup()));
+        connect(exportGroupAction, &QAction::triggered, this, &TreeDelegate::doExportGroup);
         menu->addAction(exportGroupAction);
 
         menu->addSeparator();
@@ -1114,7 +1126,7 @@ bool TreeDelegate::editorEvent(QEvent* event, QAbstractItemModel* __model, const
       QAction* findUsagesAction = new QAction(tr("Find Usages"), menu);
       findUsagesAction->setData(QVariant::fromValue((void*)node));
       findUsagesAction->setIcon(QIcon::fromTheme(QStringLiteral("edit-find")));
-      connect(findUsagesAction, SIGNAL(triggered()), this, SLOT(doFindUsages()));
+      connect(findUsagesAction, &QAction::triggered, this, &TreeDelegate::doFindUsages);
       menu->addAction(findUsagesAction);
 
       menu->addSeparator();
@@ -1124,7 +1136,7 @@ bool TreeDelegate::editorEvent(QEvent* event, QAbstractItemModel* __model, const
       cutAction->setEnabled(flags & AmuseItemCut);
       cutAction->setIcon(QIcon::fromTheme(QStringLiteral("edit-cut")));
       cutAction->setShortcut(QKeySequence::Cut);
-      connect(cutAction, SIGNAL(triggered()), this, SLOT(doCut()));
+      connect(cutAction, &QAction::triggered, this, &TreeDelegate::doCut);
       menu->addAction(cutAction);
 
       QAction* copyAction = new QAction(tr("Copy"), menu);
@@ -1132,7 +1144,7 @@ bool TreeDelegate::editorEvent(QEvent* event, QAbstractItemModel* __model, const
       copyAction->setEnabled(flags & AmuseItemCopy);
       copyAction->setIcon(QIcon::fromTheme(QStringLiteral("edit-copy")));
       copyAction->setShortcut(QKeySequence::Copy);
-      connect(copyAction, SIGNAL(triggered()), this, SLOT(doCopy()));
+      connect(copyAction, &QAction::triggered, this, &TreeDelegate::doCopy);
       menu->addAction(copyAction);
 
       QAction* pasteAction = new QAction(tr("Paste"), menu);
@@ -1140,12 +1152,12 @@ bool TreeDelegate::editorEvent(QEvent* event, QAbstractItemModel* __model, const
       pasteAction->setEnabled(g_MainWindow->m_clipboardAmuseData && flags & AmuseItemPaste);
       pasteAction->setIcon(QIcon::fromTheme(QStringLiteral("edit-paste")));
       pasteAction->setShortcut(QKeySequence::Paste);
-      connect(pasteAction, SIGNAL(triggered()), this, SLOT(doPaste()));
+      connect(pasteAction, &QAction::triggered, this, &TreeDelegate::doPaste);
       menu->addAction(pasteAction);
 
       QAction* dupeAction = new QAction(tr("Duplicate"), menu);
       dupeAction->setData(index);
-      connect(dupeAction, SIGNAL(triggered()), this, SLOT(doDuplicate()));
+      connect(dupeAction, &QAction::triggered, this, &TreeDelegate::doDuplicate);
       menu->addAction(dupeAction);
 
       QAction* deleteAction = new QAction(tr("Delete"), menu);
@@ -1153,13 +1165,13 @@ bool TreeDelegate::editorEvent(QEvent* event, QAbstractItemModel* __model, const
       deleteAction->setEnabled(flags & AmuseItemDelete);
       deleteAction->setIcon(QIcon::fromTheme(QStringLiteral("edit-delete")));
       deleteAction->setShortcut(QKeySequence::Delete);
-      connect(deleteAction, SIGNAL(triggered()), this, SLOT(doDelete()));
+      connect(deleteAction, &QAction::triggered, this, &TreeDelegate::doDelete);
       menu->addAction(deleteAction);
 
       QAction* renameAction = new QAction(tr("Rename"), menu);
       renameAction->setData(index);
       renameAction->setShortcut(Qt::Key_F2);
-      connect(renameAction, SIGNAL(triggered()), this, SLOT(doRename()));
+      connect(renameAction, &QAction::triggered, this, &TreeDelegate::doRename);
       menu->addAction(renameAction);
 
       menu->popup(ev->globalPos());
@@ -1613,15 +1625,15 @@ void MainWindow::onFocusChanged(QWidget* old, QWidget* now) {
   disconnect(m_canEditConn);
 
   if (QLineEdit* le = qobject_cast<QLineEdit*>(now)) {
-    m_cutConn = connect(m_ui.actionCut, SIGNAL(triggered()), le, SLOT(cut()));
+    m_cutConn = connect(m_ui.actionCut, &QAction::triggered, le, &QLineEdit::cut);
     m_ui.actionCut->setEnabled(le->hasSelectedText());
-    m_copyConn = connect(m_ui.actionCopy, SIGNAL(triggered()), le, SLOT(copy()));
+    m_copyConn = connect(m_ui.actionCopy, &QAction::triggered, le, &QLineEdit::copy);
     m_ui.actionCopy->setEnabled(le->hasSelectedText());
-    m_pasteConn = connect(m_ui.actionPaste, SIGNAL(triggered()), le, SLOT(paste()));
+    m_pasteConn = connect(m_ui.actionPaste, &QAction::triggered, le, &QLineEdit::paste);
     m_ui.actionPaste->setEnabled(true);
-    m_deleteConn = connect(m_ui.actionDelete, SIGNAL(triggered()), this, SLOT(onTextDelete()));
+    m_deleteConn = connect(m_ui.actionDelete, &QAction::triggered, this, &MainWindow::onTextDelete);
     m_ui.actionDelete->setEnabled(true);
-    m_canEditConn = connect(le, SIGNAL(selectionChanged()), this, SLOT(onTextSelect()));
+    m_canEditConn = connect(le, &QLineEdit::selectionChanged, this, &MainWindow::onTextSelect);
     return;
   }
 
@@ -1631,18 +1643,18 @@ void MainWindow::onFocusChanged(QWidget* old, QWidget* now) {
       editFlags = AmuseItemEditFlags(editFlags & ~AmuseItemPaste);
     setItemEditFlags(editFlags);
     if (m_projectModel) {
-      m_cutConn = connect(m_ui.actionCut, SIGNAL(triggered()), this, SLOT(outlineCutAction()));
-      m_copyConn = connect(m_ui.actionCopy, SIGNAL(triggered()), this, SLOT(outlineCopyAction()));
-      m_pasteConn = connect(m_ui.actionPaste, SIGNAL(triggered()), this, SLOT(outlinePasteAction()));
-      m_deleteConn = connect(m_ui.actionDelete, SIGNAL(triggered()), this, SLOT(outlineDeleteAction()));
+      m_cutConn = connect(m_ui.actionCut, &QAction::triggered, this, &MainWindow::outlineCutAction);
+      m_copyConn = connect(m_ui.actionCopy, &QAction::triggered, this, &MainWindow::outlineCopyAction);
+      m_pasteConn = connect(m_ui.actionPaste, &QAction::triggered, this, &MainWindow::outlinePasteAction);
+      m_deleteConn = connect(m_ui.actionDelete, &QAction::triggered, this, &MainWindow::outlineDeleteAction);
     }
   } else if (now == m_ui.editorContents || m_ui.editorContents->isAncestorOf(now)) {
     if (EditorWidget* editor = getEditorWidget()) {
       setItemEditFlags(editor->itemEditFlags());
-      m_cutConn = connect(m_ui.actionCut, SIGNAL(triggered()), editor, SLOT(itemCutAction()));
-      m_copyConn = connect(m_ui.actionCopy, SIGNAL(triggered()), editor, SLOT(itemCopyAction()));
-      m_pasteConn = connect(m_ui.actionPaste, SIGNAL(triggered()), editor, SLOT(itemPasteAction()));
-      m_deleteConn = connect(m_ui.actionDelete, SIGNAL(triggered()), editor, SLOT(itemDeleteAction()));
+      m_cutConn = connect(m_ui.actionCut, &QAction::triggered, editor, &EditorWidget::itemCutAction);
+      m_copyConn = connect(m_ui.actionCopy, &QAction::triggered, editor, &EditorWidget::itemCopyAction);
+      m_pasteConn = connect(m_ui.actionPaste, &QAction::triggered, editor, &EditorWidget::itemPasteAction);
+      m_deleteConn = connect(m_ui.actionDelete, &QAction::triggered, editor, &EditorWidget::itemDeleteAction);
     } else {
       setItemEditFlags(AmuseItemNone);
     }

--- a/Editor/NewSoundMacroDialog.cpp
+++ b/Editor/NewSoundMacroDialog.cpp
@@ -142,8 +142,8 @@ NewSoundMacroDialog::NewSoundMacroDialog(const QString& groupName, QWidget* pare
     m_combo.addItem(tr(ent.m_name), idx++);
   m_combo.setCurrentIndex(0);
 
-  QObject::connect(&m_buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
-  QObject::connect(&m_buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+  connect(&m_buttonBox, &QDialogButtonBox::accepted, this, &NewSoundMacroDialog::accept);
+  connect(&m_buttonBox, &QDialogButtonBox::rejected, this, &NewSoundMacroDialog::reject);
 
   QVBoxLayout* layout = new QVBoxLayout;
 

--- a/Editor/SampleEditor.cpp
+++ b/Editor/SampleEditor.cpp
@@ -581,14 +581,14 @@ void SampleControls::updateFileState() {
   case amuse::SampleFileState::CompressedNoWAV:
     m_makeOtherVersion->setText(tr("Make WAV Version"));
     m_makeOtherVersion->setDisabled(false);
-    m_makeOtherConn = connect(m_makeOtherVersion, SIGNAL(clicked(bool)), this, SLOT(makeWAVVersion()));
+    m_makeOtherConn = connect(m_makeOtherVersion, &QPushButton::clicked, this, &SampleControls::makeWAVVersion);
     break;
   case amuse::SampleFileState::MemoryOnlyCompressed:
   case amuse::SampleFileState::WAVRecent:
   case amuse::SampleFileState::WAVNoCompressed:
     m_makeOtherVersion->setText(tr("Make Compressed Version"));
     m_makeOtherVersion->setDisabled(false);
-    m_makeOtherConn = connect(m_makeOtherVersion, SIGNAL(clicked(bool)), this, SLOT(makeCompressedVersion()));
+    m_makeOtherConn = connect(m_makeOtherVersion, &QPushButton::clicked, this, &SampleControls::makeCompressedVersion);
     break;
   default:
     m_makeOtherVersion->setText(tr("Up To Date"));
@@ -680,28 +680,28 @@ SampleControls::SampleControls(QWidget* parent) : QFrame(parent) {
   m_zoomSlider = new QSlider(Qt::Horizontal);
   m_zoomSlider->setDisabled(true);
   m_zoomSlider->setRange(0, 99);
-  connect(m_zoomSlider, SIGNAL(valueChanged(int)), this, SLOT(zoomSliderChanged(int)));
+  connect(m_zoomSlider, qOverload<int>(&QSlider::valueChanged), this, &SampleControls::zoomSliderChanged);
   leftLayout->addWidget(m_zoomSlider, 1, 0);
 
   leftLayout->addWidget(new QLabel(tr("Loop")), 0, 1);
   m_loopCheck = new QCheckBox;
   m_loopCheck->setPalette(palette);
   m_loopCheck->setDisabled(true);
-  connect(m_loopCheck, SIGNAL(stateChanged(int)), this, SLOT(loopStateChanged(int)));
+  connect(m_loopCheck, qOverload<int>(&QCheckBox::stateChanged), this, &SampleControls::loopStateChanged);
   leftLayout->addWidget(m_loopCheck, 1, 1);
 
   leftLayout->addWidget(new QLabel(tr("Start")), 0, 2);
   m_loopStart = new QSpinBox;
   m_loopStart->setPalette(palette);
   m_loopStart->setDisabled(true);
-  connect(m_loopStart, SIGNAL(valueChanged(int)), this, SLOT(startValueChanged(int)));
+  connect(m_loopStart, qOverload<int>(&QSpinBox::valueChanged), this, &SampleControls::startValueChanged);
   leftLayout->addWidget(m_loopStart, 1, 2);
 
   leftLayout->addWidget(new QLabel(tr("End")), 0, 3);
   m_loopEnd = new QSpinBox;
   m_loopEnd->setPalette(palette);
   m_loopEnd->setDisabled(true);
-  connect(m_loopEnd, SIGNAL(valueChanged(int)), this, SLOT(endValueChanged(int)));
+  connect(m_loopEnd, qOverload<int>(&QSpinBox::valueChanged), this, &SampleControls::endValueChanged);
   leftLayout->addWidget(m_loopEnd, 1, 3);
 
   leftLayout->addWidget(new QLabel(tr("Base Pitch")), 0, 4);
@@ -710,7 +710,7 @@ SampleControls::SampleControls(QWidget* parent) : QFrame(parent) {
   m_basePitch->setDisabled(true);
   m_basePitch->setMinimum(0);
   m_basePitch->setMaximum(127);
-  connect(m_basePitch, SIGNAL(valueChanged(int)), this, SLOT(pitchValueChanged(int)));
+  connect(m_basePitch, qOverload<int>(&QSpinBox::valueChanged), this, &SampleControls::pitchValueChanged);
   leftLayout->addWidget(m_basePitch, 1, 4);
 
   leftLayout->setColumnMinimumWidth(0, 100);
@@ -731,7 +731,7 @@ SampleControls::SampleControls(QWidget* parent) : QFrame(parent) {
   m_showInBrowser = new QPushButton(ShowInGraphicalShellString());
   m_showInBrowser->setMinimumWidth(250);
   m_showInBrowser->setDisabled(true);
-  connect(m_showInBrowser, SIGNAL(clicked(bool)), this, SLOT(showInBrowser()));
+  connect(m_showInBrowser, &QPushButton::clicked, this, &SampleControls::showInBrowser);
   rightLayout->addWidget(m_showInBrowser);
 
   mainLayout->addLayout(leftLayout);

--- a/Editor/SongGroupEditor.cpp
+++ b/Editor/SongGroupEditor.cpp
@@ -262,7 +262,7 @@ QWidget* PageObjectDelegate::createEditor(QWidget* parent, const QStyleOptionVie
   const PageModel* model = static_cast<const PageModel*>(index.model());
   ProjectModel::GroupNode* group = g_MainWindow->projectModel()->getGroupNode(model->m_node.get());
   EditorFieldPageObjectNode* cb = new EditorFieldPageObjectNode(group, parent);
-  connect(cb, SIGNAL(currentIndexChanged(int)), this, SLOT(objIndexChanged()));
+  connect(cb, &EditorFieldPageObjectNode::currentIndexChanged, this, &PageObjectDelegate::objIndexChanged);
   return cb;
 }
 
@@ -322,8 +322,8 @@ MIDIFileFieldWidget::MIDIFileFieldWidget(QWidget* parent)
   layout->setSpacing(0);
   setLayout(layout);
 
-  connect(&m_le, SIGNAL(returnPressed()), this, SIGNAL(pathChanged()));
-  connect(&m_button, SIGNAL(clicked(bool)), this, SLOT(buttonPressed()));
+  connect(&m_le, &QLineEdit::returnPressed, this, &MIDIFileFieldWidget::pathChanged);
+  connect(&m_button, &QPushButton::clicked, this, &MIDIFileFieldWidget::buttonPressed);
 
   m_dialog.setFileMode(QFileDialog::ExistingFile);
   m_dialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -332,7 +332,7 @@ MIDIFileFieldWidget::MIDIFileFieldWidget(QWidget* parent)
 QWidget* MIDIFileDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& option,
                                         const QModelIndex& index) const {
   MIDIFileFieldWidget* field = new MIDIFileFieldWidget(parent);
-  connect(field, SIGNAL(pathChanged()), this, SLOT(pathChanged()));
+  connect(field, &MIDIFileFieldWidget::pathChanged, this, &MIDIFileDelegate::pathChanged);
   return field;
 }
 
@@ -377,13 +377,13 @@ bool MIDIFileDelegate::editorEvent(QEvent* event, QAbstractItemModel* model, con
       QAction* midiAction = new QAction(tr("Save As MIDI"), menu);
       midiAction->setData(path);
       midiAction->setIcon(QIcon::fromTheme(QStringLiteral("file-save")));
-      connect(midiAction, SIGNAL(triggered()), this, SLOT(doExportMIDI()));
+      connect(midiAction, &QAction::triggered, this, &MIDIFileDelegate::doExportMIDI);
       menu->addAction(midiAction);
 
       QAction* sngAction = new QAction(tr("Save As SNG"), menu);
       sngAction->setData(path);
       sngAction->setIcon(QIcon::fromTheme(QStringLiteral("file-save")));
-      connect(sngAction, SIGNAL(triggered()), this, SLOT(doExportSNG()));
+      connect(sngAction, &QAction::triggered, this, &MIDIFileDelegate::doExportSNG);
       menu->addAction(sngAction);
 
       menu->popup(ev->globalPos());
@@ -1360,7 +1360,7 @@ MIDIPlayerWidget::MIDIPlayerWidget(QModelIndex index, amuse::GroupId gid, amuse:
 , m_path(path) {
   m_playAction.setIcon(QIcon(QStringLiteral(":/icons/IconSoundMacro.svg")));
   m_button.setDefaultAction(&m_playAction);
-  connect(&m_playAction, SIGNAL(triggered()), this, SLOT(clicked()));
+  connect(&m_playAction, &QAction::triggered, this, &MIDIPlayerWidget::clicked);
 }
 
 bool SongGroupEditor::loadData(ProjectModel::SongGroupNode* node) {
@@ -1553,48 +1553,37 @@ SongGroupEditor::SongGroupEditor(QWidget* parent)
   m_tabs.addTab(m_drumTable, tr("Drum Pages"));
   m_tabs.addTab(m_setupTable, tr("MIDI Setups"));
 
-  connect(&m_tabs, SIGNAL(currentChanged(int)), this, SLOT(currentTabChanged(int)));
+  connect(&m_tabs, &ColoredTabWidget::currentChanged, this, &SongGroupEditor::currentTabChanged);
 
   m_normTable->setModel(&m_normPages);
   m_drumTable->setModel(&m_drumPages);
   m_setupTable->setModel(&m_setupList, &m_setup);
-  connect(m_normTable->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this,
-          SLOT(doSelectionChanged()));
-  connect(m_drumTable->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this,
-          SLOT(doSelectionChanged()));
-  connect(m_setupTable->m_listView->selectionModel(),
-          SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this,
-          SLOT(doSetupSelectionChanged()));
+  connect(m_normTable->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+          &SongGroupEditor::doSelectionChanged);
+  connect(m_drumTable->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+          &SongGroupEditor::doSelectionChanged);
+  connect(m_setupTable->m_listView->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+          &SongGroupEditor::doSetupSelectionChanged);
 
-  connect(&m_normPages, SIGNAL(rowsInserted(const QModelIndex&, int, int)), this,
-          SLOT(normRowsInserted(const QModelIndex&, int, int)));
-  connect(&m_normPages, SIGNAL(rowsMoved(const QModelIndex&, int, int, const QModelIndex&, int)), this,
-          SLOT(normRowsMoved(const QModelIndex&, int, int, const QModelIndex&, int)));
+  connect(&m_normPages, &PageModel::rowsInserted, this, &SongGroupEditor::normRowsInserted);
+  connect(&m_normPages, &PageModel::rowsMoved, this, &SongGroupEditor::normRowsMoved);
 
-  connect(&m_drumPages, SIGNAL(rowsInserted(const QModelIndex&, int, int)), this,
-          SLOT(drumRowsInserted(const QModelIndex&, int, int)));
-  connect(&m_drumPages, SIGNAL(rowsMoved(const QModelIndex&, int, int, const QModelIndex&, int)), this,
-          SLOT(drumRowsMoved(const QModelIndex&, int, int, const QModelIndex&, int)));
+  connect(&m_drumPages, &PageModel::rowsInserted, this, &SongGroupEditor::drumRowsInserted);
+  connect(&m_drumPages, &PageModel::rowsMoved, this, &SongGroupEditor::drumRowsMoved);
 
-  connect(&m_setupList, SIGNAL(rowsInserted(const QModelIndex&, int, int)), this,
-          SLOT(setupRowsInserted(const QModelIndex&, int, int)));
-  connect(&m_setupList, SIGNAL(rowsMoved(const QModelIndex&, int, int, const QModelIndex&, int)), this,
-          SLOT(setupRowsMoved(const QModelIndex&, int, int, const QModelIndex&, int)));
-  connect(&m_setupList, SIGNAL(rowsAboutToBeRemoved(const QModelIndex&, int, int)), this,
-          SLOT(setupRowsAboutToBeRemoved(const QModelIndex&, int, int)));
-  connect(&m_setupList, SIGNAL(modelAboutToBeReset()), this, SLOT(setupModelAboutToBeReset()));
-  connect(&m_setupList, SIGNAL(rowsRemoved(const QModelIndex&, int, int)), this, SLOT(setupDataChanged()));
-  connect(&m_setupList, SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&, const QVector<int>&)), this,
-          SLOT(setupDataChanged()));
-  connect(&m_setupList,
-          SIGNAL(layoutChanged(const QList<QPersistentModelIndex>&, QAbstractItemModel::LayoutChangeHint)), this,
-          SLOT(setupDataChanged()));
-  connect(&m_setupList, SIGNAL(modelReset()), this, SLOT(setupDataChanged()));
+  connect(&m_setupList, &SetupListModel::rowsInserted, this, &SongGroupEditor::setupRowsInserted);
+  connect(&m_setupList, &SetupListModel::rowsMoved, this, &SongGroupEditor::setupRowsMoved);
+  connect(&m_setupList, &SetupListModel::rowsAboutToBeRemoved, this, &SongGroupEditor::setupRowsAboutToBeRemoved);
+  connect(&m_setupList, &SetupListModel::modelAboutToBeReset, this, &SongGroupEditor::setupModelAboutToBeReset);
+  connect(&m_setupList, &SetupListModel::rowsRemoved, this, &SongGroupEditor::setupDataChanged);
+  connect(&m_setupList, &SetupListModel::dataChanged, this, &SongGroupEditor::setupDataChanged);
+  connect(&m_setupList, &SetupListModel::layoutChanged, this, &SongGroupEditor::setupDataChanged);
+  connect(&m_setupList, &SetupListModel::modelReset, this, &SongGroupEditor::setupDataChanged);
 
   m_addRemoveButtons.addAction()->setToolTip(tr("Add new page entry"));
-  connect(m_addRemoveButtons.addAction(), SIGNAL(triggered(bool)), this, SLOT(doAdd()));
+  connect(m_addRemoveButtons.addAction(), &QAction::triggered, this, &SongGroupEditor::doAdd);
   m_addRemoveButtons.removeAction()->setToolTip(tr("Remove selected page entries"));
-  connect(m_addRemoveButtons.removeAction(), SIGNAL(triggered(bool)), this, SLOT(itemDeleteAction()));
+  connect(m_addRemoveButtons.removeAction(), &QAction::triggered, this, &SongGroupEditor::itemDeleteAction);
 
   m_tabs.setCurrentIndex(0);
 }

--- a/Editor/SoundGroupEditor.cpp
+++ b/Editor/SoundGroupEditor.cpp
@@ -129,7 +129,7 @@ QWidget* SFXObjectDelegate::createEditor(QWidget* parent, const QStyleOptionView
   const SFXModel* model = static_cast<const SFXModel*>(index.model());
   ProjectModel::GroupNode* group = g_MainWindow->projectModel()->getGroupNode(model->m_node.get());
   EditorFieldPageObjectNode* cb = new EditorFieldPageObjectNode(group, parent);
-  connect(cb, SIGNAL(currentIndexChanged(int)), this, SLOT(objIndexChanged()));
+  connect(cb, &EditorFieldPageObjectNode::currentIndexChanged, this, &SFXObjectDelegate::objIndexChanged);
   return cb;
 }
 
@@ -554,7 +554,7 @@ SFXPlayerWidget::SFXPlayerWidget(QModelIndex index, amuse::GroupId gid, amuse::S
 : QWidget(parent), m_playAction(tr("Play")), m_button(this), m_index(index), m_groupId(gid), m_sfxId(id) {
   m_playAction.setIcon(QIcon(QStringLiteral(":/icons/IconSoundMacro.svg")));
   m_button.setDefaultAction(&m_playAction);
-  connect(&m_playAction, SIGNAL(triggered()), this, SLOT(clicked()));
+  connect(&m_playAction, &QAction::triggered, this, &SFXPlayerWidget::clicked);
 }
 
 bool SoundGroupEditor::loadData(ProjectModel::SoundGroupNode* node) {
@@ -620,20 +620,17 @@ void SoundGroupEditor::itemDeleteAction() { m_sfxTable->deleteSelection(); }
 SoundGroupEditor::SoundGroupEditor(QWidget* parent)
 : EditorWidget(parent), m_sfxs(this), m_sfxTable(new SFXTableView(this)), m_addRemoveButtons(this) {
   m_sfxTable->setModel(&m_sfxs);
-  connect(m_sfxTable->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this,
-          SLOT(doSelectionChanged()));
+  connect(m_sfxTable->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+          &SoundGroupEditor::doSelectionChanged);
 
-  connect(&m_sfxs, SIGNAL(rowsInserted(const QModelIndex&, int, int)), this,
-          SLOT(rowsInserted(const QModelIndex&, int, int)));
-  connect(&m_sfxs, SIGNAL(rowsRemoved(const QModelIndex&, int, int)), this, SLOT(sfxDataChanged()));
-  connect(&m_sfxs, SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&, const QVector<int>&)), this,
-          SLOT(sfxDataChanged()));
-  connect(&m_sfxs, SIGNAL(rowsMoved(const QModelIndex&, int, int, const QModelIndex&, int)), this,
-          SLOT(rowsMoved(const QModelIndex&, int, int, const QModelIndex&, int)));
-  connect(&m_sfxs, SIGNAL(modelReset()), this, SLOT(sfxDataChanged()));
+  connect(&m_sfxs, &SFXModel::rowsInserted, this, &SoundGroupEditor::rowsInserted);
+  connect(&m_sfxs, &SFXModel::rowsRemoved, this, &SoundGroupEditor::sfxDataChanged);
+  connect(&m_sfxs, &SFXModel::dataChanged, this, &SoundGroupEditor::sfxDataChanged);
+  connect(&m_sfxs, &SFXModel::rowsMoved, this, &SoundGroupEditor::rowsMoved);
+  connect(&m_sfxs, &SFXModel::modelReset, this, &SoundGroupEditor::sfxDataChanged);
 
   m_addRemoveButtons.addAction()->setToolTip(tr("Add new SFX entry"));
-  connect(m_addRemoveButtons.addAction(), SIGNAL(triggered(bool)), this, SLOT(doAdd()));
+  connect(m_addRemoveButtons.addAction(), &QAction::triggered, this, &SoundGroupEditor::doAdd);
   m_addRemoveButtons.removeAction()->setToolTip(tr("Remove selected SFX entries"));
-  connect(m_addRemoveButtons.removeAction(), SIGNAL(triggered(bool)), this, SLOT(itemDeleteAction()));
+  connect(m_addRemoveButtons.removeAction(), &QAction::triggered, this, &SoundGroupEditor::itemDeleteAction);
 }

--- a/Editor/SoundMacroEditor.cpp
+++ b/Editor/SoundMacroEditor.cpp
@@ -88,10 +88,11 @@ FieldSoundMacroStep::FieldSoundMacroStep(FieldProjectNode* macroField, QWidget* 
   m_spinBox.setMinimum(0);
   m_spinBox.setDisabled(true);
   m_targetButton.setDisabled(true);
-  connect(&m_spinBox, SIGNAL(valueChanged(int)), this, SIGNAL(valueChanged(int)));
-  connect(&m_targetButton, SIGNAL(pressed()), this, SLOT(targetPressed()));
-  if (macroField)
-    connect(macroField, SIGNAL(currentIndexChanged(int)), this, SLOT(updateMacroField()));
+  connect(&m_spinBox, qOverload<int>(&QSpinBox::valueChanged), this, &FieldSoundMacroStep::valueChanged);
+  connect(&m_targetButton, &QPushButton::pressed, this, &FieldSoundMacroStep::targetPressed);
+  if (macroField) {
+    connect(macroField, &FieldProjectNode::currentIndexChanged, this, &FieldSoundMacroStep::updateMacroField);
+  }
   setLayout(layout);
 }
 
@@ -128,7 +129,7 @@ CommandWidget::CommandWidget(QWidget* parent, amuse::SoundMacro::ICmd* cmd, amus
   headLayout->addWidget(&m_titleLabel);
   if (op != amuse::SoundMacro::CmdOp::End) {
     m_deleteButton.setVisible(true);
-    connect(&m_deleteButton, SIGNAL(clicked(bool)), this, SLOT(deleteClicked()));
+    connect(&m_deleteButton, &ListingDeleteButton::clicked, this, &CommandWidget::deleteClicked);
     headLayout->addWidget(&m_deleteButton);
   }
 
@@ -153,7 +154,7 @@ CommandWidget::CommandWidget(QWidget* parent, amuse::SoundMacro::ICmd* cmd, amus
           cb->setProperty("fieldIndex", f);
           cb->setProperty("fieldName", fieldName);
           cb->setCheckState(amuse::AccessField<bool>(m_cmd, field) ? Qt::Checked : Qt::Unchecked);
-          connect(cb, SIGNAL(stateChanged(int)), this, SLOT(boolChanged(int)));
+          connect(cb, qOverload<int>(&QCheckBox::stateChanged), this, &CommandWidget::boolChanged);
           layout->addWidget(cb, 1, f);
           break;
         }
@@ -192,7 +193,7 @@ CommandWidget::CommandWidget(QWidget* parent, amuse::SoundMacro::ICmd* cmd, amus
           default:
             break;
           }
-          connect(sb, SIGNAL(valueChanged(int)), this, SLOT(numChanged(int)));
+          connect(sb, qOverload<int>(&FieldSpinBox::valueChanged), this, &CommandWidget::numChanged);
           layout->addWidget(sb, 1, f);
           break;
         }
@@ -218,7 +219,7 @@ CommandWidget::CommandWidget(QWidget* parent, amuse::SoundMacro::ICmd* cmd, amus
           int index =
               collection->indexOfId(amuse::AccessField<amuse::SoundMacroIdDNA<athena::Little>>(m_cmd, field).id);
           nf->setCurrentIndex(index < 0 ? 0 : index + 1);
-          connect(nf, SIGNAL(currentIndexChanged(int)), this, SLOT(nodeChanged(int)));
+          connect(nf, &FieldProjectNode::currentIndexChanged, this, &CommandWidget::nodeChanged);
           layout->addWidget(nf, 1, f);
           break;
         }
@@ -228,7 +229,7 @@ CommandWidget::CommandWidget(QWidget* parent, amuse::SoundMacro::ICmd* cmd, amus
           sb->setProperty("fieldIndex", f);
           sb->setProperty("fieldName", fieldName);
           sb->m_spinBox.setValue(amuse::AccessField<amuse::SoundMacroStepDNA<athena::Little>>(m_cmd, field).step);
-          connect(sb, SIGNAL(valueChanged(int)), this, SLOT(numChanged(int)));
+          connect(sb, &FieldSoundMacroStep::valueChanged, this, &CommandWidget::numChanged);
           layout->addWidget(sb, 1, f);
           m_stepField = sb;
           break;
@@ -244,7 +245,7 @@ CommandWidget::CommandWidget(QWidget* parent, amuse::SoundMacro::ICmd* cmd, amus
             cb->addItem(tr(field.m_choices[j].data()));
           }
           cb->setCurrentIndex(int(amuse::AccessField<int8_t>(m_cmd, field)));
-          connect(cb, SIGNAL(currentIndexChanged(int)), this, SLOT(numChanged(int)));
+          connect(cb, qOverload<int>(&FieldComboBox::currentIndexChanged), this, &CommandWidget::numChanged);
           layout->addWidget(cb, 1, f);
           break;
         }
@@ -456,8 +457,8 @@ void CommandWidgetContainer::animateOpen() {
   m_animation->setStartValue(minimumHeight());
   m_animation->setEndValue(newHeight);
   m_animation->setEasingCurve(QEasingCurve::InOutExpo);
-  connect(m_animation, SIGNAL(valueChanged(const QVariant&)), parentWidget(), SLOT(update()));
-  connect(m_animation, SIGNAL(destroyed(QObject*)), this, SLOT(animationDestroyed()));
+  connect(m_animation, &QPropertyAnimation::valueChanged, parentWidget(), qOverload<>(&QWidget::update));
+  connect(m_animation, &QPropertyAnimation::destroyed, this, &CommandWidgetContainer::animationDestroyed);
   m_animation->start(QAbstractAnimation::DeleteWhenStopped);
 }
 
@@ -467,8 +468,8 @@ void CommandWidgetContainer::animateClosed() {
   m_animation->setStartValue(minimumHeight());
   m_animation->setEndValue(100);
   m_animation->setEasingCurve(QEasingCurve::InOutExpo);
-  connect(m_animation, SIGNAL(valueChanged(const QVariant&)), parentWidget(), SLOT(update()));
-  connect(m_animation, SIGNAL(destroyed(QObject*)), this, SLOT(animationDestroyed()));
+  connect(m_animation, &QPropertyAnimation::valueChanged, parentWidget(), qOverload<>(&QWidget::update));
+  connect(m_animation, &QPropertyAnimation::destroyed, this, &CommandWidgetContainer::animationDestroyed);
   m_animation->start(QAbstractAnimation::DeleteWhenStopped);
 }
 
@@ -1036,8 +1037,7 @@ SoundMacroEditor::SoundMacroEditor(QWidget* parent)
     m_splitter->addWidget(m_catalogue);
   }
 
-  connect(m_catalogue, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this,
-          SLOT(catalogueDoubleClicked(QTreeWidgetItem*, int)));
+  connect(m_catalogue, &SoundMacroCatalogue::itemDoubleClicked, this, &SoundMacroEditor::catalogueDoubleClicked);
 
   m_splitter->setCollapsible(0, false);
   QGridLayout* layout = new QGridLayout;

--- a/Editor/StatusBarWidget.cpp
+++ b/Editor/StatusBarWidget.cpp
@@ -34,7 +34,7 @@ StatusBarWidget::StatusBarWidget(QWidget* parent)
   m_volumeIcon.setPixmap(m_volumeIcons[0].pixmap(16, 16));
   QString volTip = tr("Master volume level");
   m_volumeIcon.setToolTip(volTip);
-  connect(&m_volumeSlider, SIGNAL(valueChanged(int)), this, SLOT(volumeChanged(int)));
+  connect(&m_volumeSlider, qOverload<int>(&QSlider::valueChanged), this, &StatusBarWidget::volumeChanged);
   m_volumeSlider.setRange(0, 100);
   m_volumeSlider.setFixedWidth(100);
   m_volumeSlider.setToolTip(volTip);

--- a/Editor/StatusBarWidget.hpp
+++ b/Editor/StatusBarWidget.hpp
@@ -45,21 +45,28 @@ public:
   explicit StatusBarWidget(QWidget* parent = Q_NULLPTR);
   void setNormalMessage(const QString& message) { m_normalMessage.setText(message); }
   void setVoiceCount(int voices);
-  void connectKillClicked(const QObject* receiver, const char* method) {
-    connect(&m_killButton, SIGNAL(clicked(bool)), receiver, method);
+
+  template <typename Receiver>
+  void connectKillClicked(const Receiver* receiver, void (Receiver::*method)()) {
+    connect(&m_killButton, &QPushButton::clicked, receiver, method);
   }
-  void connectFXPressed(const QObject* receiver, const char* method) {
-    connect(&m_fxButton, SIGNAL(pressed()), receiver, method);
+  template <typename Receiver>
+  void connectFXPressed(const Receiver* receiver, void (Receiver::*method)()) {
+    connect(&m_fxButton, &FXButton::pressed, receiver, method);
   }
   void setFXDown(bool down) { m_fxButton.setDown(down); }
-  void connectVolumeSlider(const QObject* receiver, const char* method) {
-    connect(&m_volumeSlider, SIGNAL(valueChanged(int)), receiver, method);
+
+  template <typename Receiver>
+  void connectVolumeSlider(const Receiver* receiver, void (Receiver::*method)(int)) {
+    connect(&m_volumeSlider, qOverload<int>(&QSlider::valueChanged), receiver, method);
   }
-  void connectASlider(const QObject* receiver, const char* method) {
-    connect(&m_aSlider, SIGNAL(valueChanged(int)), receiver, method);
+  template <typename Receiver>
+  void connectASlider(const Receiver* receiver, void (Receiver::*method)(int)) {
+    connect(&m_aSlider, qOverload<int>(&QSlider::valueChanged), receiver, method);
   }
-  void connectBSlider(const QObject* receiver, const char* method) {
-    connect(&m_bSlider, SIGNAL(valueChanged(int)), receiver, method);
+  template <typename Receiver>
+  void connectBSlider(const Receiver* receiver, void (Receiver::*method)(int)) {
+    connect(&m_bSlider, qOverload<int>(&QSlider::valueChanged), receiver, method);
   }
   void setVolumeValue(int vol) { m_volumeSlider.setValue(vol); }
 

--- a/Editor/StudioSetupWidget.cpp
+++ b/Editor/StudioSetupWidget.cpp
@@ -153,7 +153,7 @@ Uint32X8Popup::Uint32X8Popup(int min, int max, QWidget* parent) : QFrame(parent,
     slider->setToolTip(QStringLiteral("[%1,%2]").arg(min).arg(max));
     slider->setProperty("chanIdx", i);
     slider->setRange(min, max);
-    connect(slider, SIGNAL(valueChanged(int)), this, SLOT(doValueChanged(int)));
+    connect(slider, qOverload<int>(&FieldSlider::valueChanged), this, &Uint32X8Popup::doValueChanged);
     layout->addWidget(slider, i, 1);
   }
   setLayout(layout);
@@ -169,7 +169,7 @@ void Uint32X8Popup::doValueChanged(int val) {
 
 Uint32X8Button::Uint32X8Button(int min, int max, QWidget* parent)
 : QPushButton(parent), m_popup(new Uint32X8Popup(min, max, this)) {
-  connect(this, SIGNAL(pressed()), this, SLOT(onPressed()));
+  connect(this, &Uint32X8Button::pressed, this, &Uint32X8Button::onPressed);
 }
 
 void Uint32X8Button::paintEvent(QPaintEvent*) {
@@ -231,7 +231,7 @@ EffectWidget::EffectWidget(QWidget* parent, amuse::EffectBaseTypeless* effect, a
   headLayout->addWidget(&m_titleLabel);
 
   m_deleteButton.setVisible(true);
-  connect(&m_deleteButton, SIGNAL(clicked(bool)), this, SLOT(deleteClicked()));
+  connect(&m_deleteButton, &ListingDeleteButton::clicked, this, &EffectWidget::deleteClicked);
   headLayout->addWidget(&m_deleteButton);
 
   mainLayout->addLayout(headLayout);
@@ -255,7 +255,7 @@ EffectWidget::EffectWidget(QWidget* parent, amuse::EffectBaseTypeless* effect, a
           sb->setRange(int(field.m_min), int(field.m_max));
           sb->setToolTip(QStringLiteral("[%1,%2]").arg(int(field.m_min)).arg(int(field.m_max)));
           sb->setValue(GetEffectParm<uint32_t>(m_effect, f, 0));
-          connect(sb, SIGNAL(valueChanged(int)), this, SLOT(numChanged(int)));
+          connect(sb, qOverload<int>(&FieldSlider::valueChanged), this, qOverload<int>(&EffectWidget::numChanged));
           layout->addWidget(sb, 1, f);
           break;
         }
@@ -264,7 +264,7 @@ EffectWidget::EffectWidget(QWidget* parent, amuse::EffectBaseTypeless* effect, a
           sb->popup()->setProperty("fieldIndex", f);
           for (int i = 0; i < 8; ++i)
             sb->popup()->setValue(i, GetEffectParm<uint32_t>(m_effect, f, i));
-          connect(sb->popup(), SIGNAL(valueChanged(int, int)), this, SLOT(chanNumChanged(int, int)));
+          connect(sb->popup(), &Uint32X8Popup::valueChanged, this, &EffectWidget::chanNumChanged);
           layout->addWidget(sb, 1, f);
           break;
         }
@@ -274,7 +274,8 @@ EffectWidget::EffectWidget(QWidget* parent, amuse::EffectBaseTypeless* effect, a
           sb->setRange(field.m_min, field.m_max);
           sb->setToolTip(QStringLiteral("[%1,%2]").arg(field.m_min).arg(field.m_max));
           sb->setValue(GetEffectParm<float>(m_effect, f, 0));
-          connect(sb, SIGNAL(valueChanged(double)), this, SLOT(numChanged(double)));
+          connect(sb, qOverload<double>(&FieldDoubleSlider::valueChanged), this,
+                  qOverload<double>(&EffectWidget::numChanged));
           layout->addWidget(sb, 1, f);
           break;
         }
@@ -354,8 +355,8 @@ void EffectWidgetContainer::animateOpen() {
   m_animation->setStartValue(minimumHeight());
   m_animation->setEndValue(newHeight);
   m_animation->setEasingCurve(QEasingCurve::InOutExpo);
-  connect(m_animation, SIGNAL(valueChanged(const QVariant&)), parentWidget(), SLOT(update()));
-  connect(m_animation, SIGNAL(destroyed(QObject*)), this, SLOT(animationDestroyed()));
+  connect(m_animation, &QPropertyAnimation::valueChanged, parentWidget(), qOverload<>(&QWidget::update));
+  connect(m_animation, &QPropertyAnimation::destroyed, this, &EffectWidgetContainer::animationDestroyed);
   m_animation->start(QAbstractAnimation::DeleteWhenStopped);
 }
 
@@ -365,8 +366,8 @@ void EffectWidgetContainer::animateClosed() {
   m_animation->setStartValue(minimumHeight());
   m_animation->setEndValue(100);
   m_animation->setEasingCurve(QEasingCurve::InOutExpo);
-  connect(m_animation, SIGNAL(valueChanged(const QVariant&)), parentWidget(), SLOT(update()));
-  connect(m_animation, SIGNAL(destroyed(QObject*)), this, SLOT(animationDestroyed()));
+  connect(m_animation, &QPropertyAnimation::valueChanged, parentWidget(), qOverload<>(&QWidget::update));
+  connect(m_animation, &QPropertyAnimation::destroyed, this, &EffectWidgetContainer::animationDestroyed);
   m_animation->start(QAbstractAnimation::DeleteWhenStopped);
 }
 
@@ -866,8 +867,7 @@ StudioSetupWidget::StudioSetupWidget(QWidget* parent)
     m_splitter->addWidget(m_catalogue);
   }
 
-  connect(m_catalogue, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this,
-          SLOT(catalogueDoubleClicked(QTreeWidgetItem*, int)));
+  connect(m_catalogue, &EffectCatalogue::itemDoubleClicked, this, &StudioSetupWidget::catalogueDoubleClicked);
 
   m_splitter->setCollapsible(0, false);
   QGridLayout* layout = new QGridLayout;


### PR DESCRIPTION
Migrates the UI signals and slots over to the new Qt 5 syntax. This syntax is nicer, as the compiler can report errors at compile-time, as opposed to the other method which would require a runtime error to indicate any issues with the signals and slots.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/amuse/13)
<!-- Reviewable:end -->
