### PR TITLE
CMakeLists: Migrate Qt checking over to using components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ if(TARGET boo AND NOT WINDOWS_STORE AND NOT NX)
   endif()
 
   # Editor
-  find_package(Qt5Widgets)
+  find_package(Qt5 COMPONENTS Widgets)
   if (Qt5Widgets_FOUND)
     message(STATUS "Qt5 found, amuse-gui will be built")
     add_subdirectory(Editor)

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -2,12 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Network REQUIRED)
-find_package(Qt5Xml REQUIRED)
-find_package(Qt5Svg REQUIRED)
-find_package(Qt5Qml REQUIRED)
-find_package(Qt5LinguistTools REQUIRED)
+find_package(Qt5 COMPONENTS LinguistTools Network Qml Svg Widgets Xml REQUIRED)
 
 if(WIN32)
   list(APPEND PLAT_SRCS platforms/win/amuse-gui.rc platforms/win/amuse-gui.manifest)
@@ -76,12 +71,24 @@ if(COMMAND add_sanitizers)
 endif()
 
 set_target_properties(amuse-gui PROPERTIES
-        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/platforms/mac/Info.plist")
+  MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/platforms/mac/Info.plist"
+)
 
-target_link_libraries(amuse-gui ${PLAT_LIBS}
-        ${Qt5Widgets_LIBRARIES}
-        ${Qt5Network_LIBRARIES}
-        ${Qt5Xml_LIBRARIES}
-        ${Qt5Svg_LIBRARIES}
-        ${Qt5Qml_LIBRARIES}
-        amuse boo ${BOO_SYS_LIBS} logvisor athena-core xxhash ${ZLIB_LIBRARIES} lzokay)
+target_link_libraries(amuse-gui
+  ${PLAT_LIBS}
+
+  Qt5::Network
+  Qt5::Qml
+  Qt5::Svg
+  Qt5::Widgets
+  Qt5::Xml
+
+  amuse
+  athena-core
+  boo
+  ${BOO_SYS_LIBS}
+  logvisor
+  lzokay
+  xxhash
+  ${ZLIB_LIBRARIES}
+)


### PR DESCRIPTION
Qt has since made their library usable with the components system within CMake, so we can just use that to simplify the library finding and linking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/amuse/15)
<!-- Reviewable:end -->
