### PR TITLE
Editor/CMakeLists: Enable AUTOMOC, AUTORCC, and AUTOUI

### DIFF
--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -27,45 +27,71 @@ QT5_ADD_RESOURCES(qrc_translation_res.cpp ${CMAKE_CURRENT_BINARY_DIR}/translatio
 QT5_WRAP_UI(MAIN_WINDOW_UI MainWindow.ui)
 
 QT5_WRAP_CPP(AMUSE_MOC
-        Common.hpp
-        MainWindow.hpp
-        KeyboardWidget.hpp
-        StatusBarWidget.hpp
-        ProjectModel.hpp
-        EditorWidget.hpp
-        SoundMacroEditor.hpp
-        ADSREditor.hpp
-        CurveEditor.hpp
-        KeymapEditor.hpp
-        LayersEditor.hpp
-        SampleEditor.hpp
-        SoundGroupEditor.hpp
-        SongGroupEditor.hpp
-        NewSoundMacroDialog.hpp
-        StudioSetupWidget.hpp)
+  ADSREditor.hpp
+  Common.hpp
+  CurveEditor.hpp
+  EditorWidget.hpp
+  LayersEditor.hpp
+  MainWindow.hpp
+  NewSoundMacroDialog.hpp
+  KeyboardWidget.hpp
+  KeymapEditor.hpp
+  ProjectModel.hpp
+  SampleEditor.hpp
+  SongGroupEditor.hpp
+  SoundGroupEditor.hpp
+  SoundMacroEditor.hpp
+  StatusBarWidget.hpp
+  StudioSetupWidget.hpp
+)
 
 add_executable(amuse-gui WIN32 MACOSX_BUNDLE
-        Common.hpp Common.cpp
-        MainWindow.ui ${MAIN_WINDOW_UI} MainWindow.hpp MainWindow.cpp
-        KeyboardWidget.hpp KeyboardWidget.cpp
-        StatusBarWidget.hpp StatusBarWidget.cpp
-        ProjectModel.hpp ProjectModel.cpp
-        EditorWidget.hpp EditorWidget.cpp
-        SoundMacroEditor.hpp SoundMacroEditor.cpp
-        ADSREditor.hpp ADSREditor.cpp
-        CurveEditor.hpp CurveEditor.cpp
-        KeymapEditor.hpp KeymapEditor.cpp
-        LayersEditor.hpp LayersEditor.cpp
-        SampleEditor.hpp SampleEditor.cpp
-        SoundGroupEditor.hpp SoundGroupEditor.cpp
-        SongGroupEditor.hpp SongGroupEditor.cpp
-        NewSoundMacroDialog.hpp NewSoundMacroDialog.cpp
-        StudioSetupWidget.hpp StudioSetupWidget.cpp
-        MIDIReader.hpp MIDIReader.cpp
-        resources/resources.qrc qrc_resources.cpp
-        ${QM_FILES} qrc_translation_res.cpp
-        ${AMUSE_MOC} ${PLAT_SRCS}
-        main.cpp)
+  ADSREditor.cpp
+  ADSREditor.hpp
+  Common.cpp
+  Common.hpp
+  CurveEditor.cpp
+  CurveEditor.hpp
+  EditorWidget.cpp
+  EditorWidget.hpp
+  KeyboardWidget.cpp
+  KeyboardWidget.hpp
+  KeymapEditor.cpp
+  KeymapEditor.hpp
+  LayersEditor.cpp
+  LayersEditor.hpp
+  MainWindow.cpp
+  MainWindow.hpp
+  MainWindow.ui
+  MIDIReader.cpp
+  MIDIReader.hpp
+  NewSoundMacroDialog.cpp
+  NewSoundMacroDialog.hpp
+  ProjectModel.cpp
+  ProjectModel.hpp
+  SampleEditor.cpp
+  SampleEditor.hpp
+  SongGroupEditor.cpp
+  SongGroupEditor.hpp
+  SoundGroupEditor.cpp
+  SoundGroupEditor.hpp
+  SoundMacroEditor.cpp
+  SoundMacroEditor.hpp
+  StatusBarWidget.cpp
+  StatusBarWidget.hpp
+  StudioSetupWidget.cpp
+  StudioSetupWidget.hpp
+
+  main.cpp
+  qrc_resources.cpp
+  qrc_translation_res.cpp
+  resources/resources.qrc
+
+  ${AMUSE_MOC}
+  ${MAIN_WINDOW_UI}
+  ${PLAT_SRCS}
+  ${QM_FILES}
+)
 if(COMMAND add_sanitizers)
   add_sanitizers(amuse-gui)
 endif()

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
-# Automatically handle invoking moc
+# Automatically handle invoking autorcc, moc, and uic.
 set(CMAKE_AUTOMOC ON)
-
-# Automatically handle invoking uic
+set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(Qt5 COMPONENTS LinguistTools Network Qml Svg Widgets Xml REQUIRED)
 
@@ -15,9 +14,6 @@ set(TRANSLATIONS
   resources/lang_de.ts
 )
 QT5_CREATE_TRANSLATION(QM_FILES ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../lib ${TRANSLATIONS})
-
-QT5_ADD_RESOURCES(qrc_resources.cpp resources/resources.qrc)
-QT5_ADD_RESOURCES(qrc_translation_res.cpp ${CMAKE_CURRENT_BINARY_DIR}/translation_res.qrc OPTIONS -no-compress)
 
 add_executable(amuse-gui WIN32 MACOSX_BUNDLE
   ADSREditor.cpp
@@ -58,9 +54,8 @@ add_executable(amuse-gui WIN32 MACOSX_BUNDLE
 
   main.cpp
 
-  qrc_resources.cpp
-  qrc_translation_res.cpp
   resources/resources.qrc
+  ${CMAKE_CURRENT_BINARY_DIR}/translation_res.qrc
 
   ${QM_FILES}
 )

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+# Automatically handle invoking moc
+set(CMAKE_AUTOMOC ON)
+
 find_package(Qt5 COMPONENTS LinguistTools Network Qml Svg Widgets Xml REQUIRED)
 
 configure_file(resources/translation_res.qrc translation_res.qrc @ONLY)
@@ -14,25 +17,6 @@ QT5_ADD_RESOURCES(qrc_resources.cpp resources/resources.qrc)
 QT5_ADD_RESOURCES(qrc_translation_res.cpp ${CMAKE_CURRENT_BINARY_DIR}/translation_res.qrc OPTIONS -no-compress)
 
 QT5_WRAP_UI(MAIN_WINDOW_UI MainWindow.ui)
-
-QT5_WRAP_CPP(AMUSE_MOC
-  ADSREditor.hpp
-  Common.hpp
-  CurveEditor.hpp
-  EditorWidget.hpp
-  LayersEditor.hpp
-  MainWindow.hpp
-  NewSoundMacroDialog.hpp
-  KeyboardWidget.hpp
-  KeymapEditor.hpp
-  ProjectModel.hpp
-  SampleEditor.hpp
-  SongGroupEditor.hpp
-  SoundGroupEditor.hpp
-  SoundMacroEditor.hpp
-  StatusBarWidget.hpp
-  StudioSetupWidget.hpp
-)
 
 add_executable(amuse-gui WIN32 MACOSX_BUNDLE
   ADSREditor.cpp
@@ -76,7 +60,6 @@ add_executable(amuse-gui WIN32 MACOSX_BUNDLE
   qrc_translation_res.cpp
   resources/resources.qrc
 
-  ${AMUSE_MOC}
   ${MAIN_WINDOW_UI}
   ${QM_FILES}
 )

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -5,6 +5,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Automatically handle invoking moc
 set(CMAKE_AUTOMOC ON)
 
+# Automatically handle invoking uic
+set(CMAKE_AUTOUIC ON)
+
 find_package(Qt5 COMPONENTS LinguistTools Network Qml Svg Widgets Xml REQUIRED)
 
 configure_file(resources/translation_res.qrc translation_res.qrc @ONLY)
@@ -15,8 +18,6 @@ QT5_CREATE_TRANSLATION(QM_FILES ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOUR
 
 QT5_ADD_RESOURCES(qrc_resources.cpp resources/resources.qrc)
 QT5_ADD_RESOURCES(qrc_translation_res.cpp ${CMAKE_CURRENT_BINARY_DIR}/translation_res.qrc OPTIONS -no-compress)
-
-QT5_WRAP_UI(MAIN_WINDOW_UI MainWindow.ui)
 
 add_executable(amuse-gui WIN32 MACOSX_BUNDLE
   ADSREditor.cpp
@@ -56,11 +57,11 @@ add_executable(amuse-gui WIN32 MACOSX_BUNDLE
   StudioSetupWidget.hpp
 
   main.cpp
+
   qrc_resources.cpp
   qrc_translation_res.cpp
   resources/resources.qrc
 
-  ${MAIN_WINDOW_UI}
   ${QM_FILES}
 )
 

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -4,21 +4,10 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(Qt5 COMPONENTS LinguistTools Network Qml Svg Widgets Xml REQUIRED)
 
-if(WIN32)
-  list(APPEND PLAT_SRCS platforms/win/amuse-gui.rc platforms/win/amuse-gui.manifest)
-elseif(APPLE)
-  list(APPEND PLAT_SRCS platforms/mac/mainicon.icns MacOSExtras.mm)
-  set_source_files_properties(platforms/mac/mainicon.icns PROPERTIES
-          MACOSX_PACKAGE_LOCATION Resources)
-endif()
-
-add_subdirectory(platforms/freedesktop)
-declare_qticon_target()
-list(APPEND PLAT_SRCS mainicon_qt.cpp)
-
 configure_file(resources/translation_res.qrc translation_res.qrc @ONLY)
 set(TRANSLATIONS
-    resources/lang_de.ts)
+  resources/lang_de.ts
+)
 QT5_CREATE_TRANSLATION(QM_FILES ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../lib ${TRANSLATIONS})
 
 QT5_ADD_RESOURCES(qrc_resources.cpp resources/resources.qrc)
@@ -89,9 +78,28 @@ add_executable(amuse-gui WIN32 MACOSX_BUNDLE
 
   ${AMUSE_MOC}
   ${MAIN_WINDOW_UI}
-  ${PLAT_SRCS}
   ${QM_FILES}
 )
+
+if(WIN32)
+  target_sources(amuse-gui PRIVATE
+    platforms/win/amuse-gui.rc
+    platforms/win/amuse-gui.manifest
+  )
+elseif(APPLE)
+  target_sources(amuse-gui PRIVATE
+    MacOSExtras.mm
+    platforms/mac/mainicon.icns
+  )
+  set_source_files_properties(platforms/mac/mainicon.icns PROPERTIES
+    MACOSX_PACKAGE_LOCATION Resources
+  )
+endif()
+
+add_subdirectory(platforms/freedesktop)
+declare_qticon_target()
+target_sources(amuse-gui PRIVATE mainicon_qt.cpp)
+
 if(COMMAND add_sanitizers)
   add_sanitizers(amuse-gui)
 endif()


### PR DESCRIPTION
This allows the build system to automatically handle the generation of moc output, resources, and UI source code without us needing to manually do the book keeping ourselves within the source CMake source file.

Another nice benefit is this allows the build system to cache the generated file results, which will make it only rebuild files that have been modified, as opposed to regenerating and rebuilding all of the moc files, saving on build times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/amuse/20)
<!-- Reviewable:end -->
