### PR TITLE
Editor/CMakeLists: Add a few Qt compilation definitions to enforce correctness

### DIFF
--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -68,6 +68,9 @@ target_compile_definitions(amuse-gui PRIVATE
   # Disable narrowing conversions in signal/slot connect() calls.
   -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT
 
+  # Disable implicit QString->QUrl conversions to enforce use of proper resolving functions.
+  -DQT_NO_URL_CAST_FROM_STRING
+
   # Allows for more efficient string concatenation, resulting in less temporaries.
   -DQT_USE_QSTRINGBUILDER 
 )

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -65,6 +65,9 @@ target_compile_definitions(amuse-gui PRIVATE
   -DQT_NO_CAST_FROM_ASCII
   -DQT_NO_CAST_TO_ASCII
 
+  # Disable implicit conversions of QByteArray to const char* or const void*
+  -DQT_NO_CAST_FROM_BYTEARRAY
+
   # Disable narrowing conversions in signal/slot connect() calls.
   -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT
 

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -61,6 +61,10 @@ add_executable(amuse-gui WIN32 MACOSX_BUNDLE
 )
 
 target_compile_definitions(amuse-gui PRIVATE
+  # Disable implicit conversions from ASCII to QString.
+  -DQT_NO_CAST_FROM_ASCII
+  -DQT_NO_CAST_TO_ASCII
+
   # Allows for more efficient string concatenation, resulting in less temporaries.
   -DQT_USE_QSTRINGBUILDER 
 )

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -60,6 +60,11 @@ add_executable(amuse-gui WIN32 MACOSX_BUNDLE
   ${QM_FILES}
 )
 
+target_compile_definitions(amuse-gui PRIVATE
+  # Allows for more efficient string concatenation, resulting in less temporaries.
+  -DQT_USE_QSTRINGBUILDER 
+)
+
 if(WIN32)
   target_sources(amuse-gui PRIVATE
     platforms/win/amuse-gui.rc

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -65,6 +65,9 @@ target_compile_definitions(amuse-gui PRIVATE
   -DQT_NO_CAST_FROM_ASCII
   -DQT_NO_CAST_TO_ASCII
 
+  # Disable narrowing conversions in signal/slot connect() calls.
+  -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT
+
   # Allows for more efficient string concatenation, resulting in less temporaries.
   -DQT_USE_QSTRINGBUILDER 
 )

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -68,6 +68,9 @@ target_compile_definitions(amuse-gui PRIVATE
   # Disable narrowing conversions in signal/slot connect() calls.
   -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT
 
+  # Disable unsafe overloads of QProcess' start() function.
+  -DQT_NO_PROCESS_COMBINED_ARGUMENT_START
+
   # Disable implicit QString->QUrl conversions to enforce use of proper resolving functions.
   -DQT_NO_URL_CAST_FROM_STRING
 

--- a/Editor/ProjectModel.hpp
+++ b/Editor/ProjectModel.hpp
@@ -259,7 +259,7 @@ public:
     amuse::ObjToken<amuse::SongGroupIndex> m_index;
     SongGroupNode(const QString& name, amuse::ObjToken<amuse::SongGroupIndex> index) : INode(name), m_index(index) {}
     SongGroupNode(amuse::GroupId id, amuse::ObjToken<amuse::SongGroupIndex> index)
-    : INode(amuse::GroupId::CurNameDB->resolveNameFromId(id).data()), m_id(id), m_index(index) {}
+    : INode(QString::fromUtf8(amuse::GroupId::CurNameDB->resolveNameFromId(id).data())), m_id(id), m_index(index) {}
 
     static QIcon Icon;
     Type type() const override { return Type::SongGroup; }
@@ -285,7 +285,7 @@ public:
     amuse::ObjToken<amuse::SFXGroupIndex> m_index;
     SoundGroupNode(const QString& name, amuse::ObjToken<amuse::SFXGroupIndex> index) : INode(name), m_index(index) {}
     SoundGroupNode(amuse::GroupId id, amuse::ObjToken<amuse::SFXGroupIndex> index)
-    : INode(amuse::GroupId::CurNameDB->resolveNameFromId(id).data()), m_id(id), m_index(index) {}
+    : INode(QString::fromUtf8(amuse::GroupId::CurNameDB->resolveNameFromId(id).data())), m_id(id), m_index(index) {}
 
     static QIcon Icon;
     Type type() const override { return Type::SoundGroup; }
@@ -336,7 +336,7 @@ public:
     amuse::ObjToken<T> m_obj;
     PoolObjectNode(const QString& name, amuse::ObjToken<T> obj) : BasePoolObjectNode(name), m_obj(obj) {}
     PoolObjectNode(ID id, amuse::ObjToken<T> obj)
-    : BasePoolObjectNode(id, ID::CurNameDB->resolveNameFromId(id).data()), m_obj(obj) {}
+    : BasePoolObjectNode(id, QString::fromUtf8(ID::CurNameDB->resolveNameFromId(id).data())), m_obj(obj) {}
 
     Type type() const override { return TP; }
     AmuseItemEditFlags editFlags() const override { return TP == INode::Type::Sample ? AmuseItemNoCut : AmuseItemAll; }

--- a/Editor/SongGroupEditor.cpp
+++ b/Editor/SongGroupEditor.cpp
@@ -839,7 +839,7 @@ QVariant SetupListModel::data(const QModelIndex& index, int role) const {
       if (role == Qt::ForegroundRole)
         return QVariant();
       g_MainWindow->projectModel()->setIdDatabases(m_node.get());
-      return amuse::SongId::CurNameDB->resolveNameFromId(entry->first.id).data();
+      return QString::fromUtf8(amuse::SongId::CurNameDB->resolveNameFromId(entry->first.id).data());
     } else if (index.column() == 1) {
       QString songPath = g_MainWindow->projectModel()->getMIDIPathOfSong(entry.m_it->first);
       if (songPath.isEmpty()) {

--- a/Editor/SoundGroupEditor.cpp
+++ b/Editor/SoundGroupEditor.cpp
@@ -232,7 +232,7 @@ QVariant SFXModel::data(const QModelIndex& index, int role) const {
     switch (index.column()) {
     case 0: {
       g_MainWindow->projectModel()->setIdDatabases(m_node.get());
-      return amuse::SFXId::CurNameDB->resolveNameFromId(entry->first.id).data();
+      return QString::fromUtf8(amuse::SFXId::CurNameDB->resolveNameFromId(entry->first.id).data());
     }
     case 1: {
       ProjectModel::GroupNode* group = g_MainWindow->projectModel()->getGroupNode(m_node.get());

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -60,12 +60,12 @@ int main(int argc, char* argv[]) {
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
-  QApplication::setStyle(new ColoredTabBarStyle(QStyleFactory::create("Fusion")));
+  QApplication::setStyle(new ColoredTabBarStyle(QStyleFactory::create(QStringLiteral("Fusion"))));
   QApplication a(argc, argv);
   QApplication::setWindowIcon(MakeAppIcon());
 
-  a.setOrganizationName("AxioDL");
-  a.setApplicationName("Amuse");
+  a.setOrganizationName(QStringLiteral("AxioDL"));
+  a.setApplicationName(QStringLiteral("Amuse"));
 
   QPalette darkPalette;
   darkPalette.setColor(QPalette::Window, QColor(53, 53, 53));
@@ -102,8 +102,9 @@ int main(int argc, char* argv[]) {
 
   Q_INIT_RESOURCE(translation_res);
   QTranslator translator;
-  if (translator.load(QLocale(), QLatin1String("lang"), QLatin1String("_"), QLatin1String(":/translations")))
+  if (translator.load(QLocale(), QStringLiteral("lang"), QStringLiteral("_"), QStringLiteral(":/translations"))) {
     a.installTranslator(&translator);
+  }
 
   MainWindow w;
   g_MainWindow = &w;


### PR DESCRIPTION
Adds a few compilation definitions that make it a little more difficult to misuse various APIs within the Qt libraries. Each definition comes with its own rationale:

- [QT_NO_CAST_FROM/TO_ASCII](https://doc.qt.io/qt-5/qstring.html#converting-between-8-bit-strings-and-unicode-strings)
- [QT_NO_CAST_FROM_BYTEARRAY](https://doc.qt.io/qt-5/qbytearray.html#QT_NO_CAST_FROM_BYTEARRAY)
- [QT_NO_NARROWING_CONVERSIONS_IN_CONNECT](https://www.kdab.com/disabling-narrowing-conversions-in-signal-slot-connections/)
- [QT_NO_PROCESS_COMBINED_ARGUMENT_START](https://doc.qt.io/qt-5/qprocess.html#start-1)
- [QT_NO_URL_CAST_FROM_STRING](https://doc.qt.io/qt-5/qurl.html#QT_NO_URL_CAST_FROM_STRING)
- [QT_USE_QSTRINGBUILDER](https://blog.qt.io/blog/2011/06/13/string-concatenation-with-qstringbuilder/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/amuse/21)
<!-- Reviewable:end -->
