### PR TITLE
Editor/KeyboardWidget: Make use of std::array where applicable

### DIFF
--- a/Editor/KeyboardWidget.hpp
+++ b/Editor/KeyboardWidget.hpp
@@ -1,16 +1,18 @@
 #pragma once
 
+#include <array>
+
 #include <QSlider>
 #include <QString>
 #include <QSvgWidget>
 #include <QWheelEvent>
 #include <QWidget>
 
-extern const QString NaturalKeyNames[7];
-extern const QString SharpKeyNames[5];
-extern const QString KeyStrings[12];
-extern const int NaturalKeyNumbers[7];
-extern const int SharpKeyNumbers[5];
+extern const std::array<QString, 7> NaturalKeyNames;
+extern const std::array<QString, 5> SharpKeyNames;
+extern const std::array<QString, 12> KeyStrings;
+extern const std::array<int, 7> NaturalKeyNumbers;
+extern const std::array<int, 5> SharpKeyNumbers;
 
 class KeyboardWidget;
 class StatusBarFocus;
@@ -18,8 +20,8 @@ class StatusBarFocus;
 class KeyboardOctave : public QSvgWidget {
   Q_OBJECT
   int m_octave;
-  QRectF m_natural[7];
-  QRectF m_sharp[5];
+  std::array<QRectF, 7> m_natural;
+  std::array<QRectF, 5> m_sharp;
   QTransform m_widgetToSvg;
 
 public:
@@ -31,7 +33,7 @@ public:
 
 class KeyboardWidget : public QWidget {
   Q_OBJECT
-  KeyboardOctave* m_widgets[11];
+  std::array<KeyboardOctave*, 11> m_widgets{};
   StatusBarFocus* m_statusFocus = nullptr;
   int m_lastOctave = -1;
   int m_lastKey = -1;

--- a/Editor/KeymapEditor.cpp
+++ b/Editor/KeymapEditor.cpp
@@ -160,7 +160,7 @@ KeymapView::KeymapView(QWidget* parent)
 
   size_t k = 0;
   for (size_t i = 0; i < 11; ++i) {
-    for (size_t j = 0; j < 12 && k < m_keyTexts.size(); ++j) {
+    for (size_t j = 0; j < KeyStrings.size() && k < m_keyTexts.size(); ++j) {
       m_keyTexts[k++].setText(QStringLiteral("%1%2").arg(KeyStrings[j]).arg(i - 1));
     }
   }
@@ -169,16 +169,20 @@ KeymapView::KeymapView(QWidget* parent)
   m_keyPalettes.fill(-1);
 
   for (size_t i = 0; i < m_natural.size(); ++i) {
-    if (m_octaveRenderer.elementExists(NaturalKeyNames[i])) {
-      m_natural[i] = m_octaveRenderer.matrixForElement(NaturalKeyNames[i])
-                         .mapRect(m_octaveRenderer.boundsOnElement(NaturalKeyNames[i]));
+    const auto& naturalKeyName = NaturalKeyNames[i];
+
+    if (m_octaveRenderer.elementExists(naturalKeyName)) {
+      m_natural[i] =
+          m_octaveRenderer.matrixForElement(naturalKeyName).mapRect(m_octaveRenderer.boundsOnElement(naturalKeyName));
     }
   }
 
   for (size_t i = 0; i < m_sharp.size(); ++i) {
-    if (m_octaveRenderer.elementExists(SharpKeyNames[i])) {
-      m_sharp[i] = m_octaveRenderer.matrixForElement(SharpKeyNames[i])
-                       .mapRect(m_octaveRenderer.boundsOnElement(SharpKeyNames[i]));
+    const auto& sharpKeyName = SharpKeyNames[i];
+
+    if (m_octaveRenderer.elementExists(sharpKeyName)) {
+      m_sharp[i] =
+          m_octaveRenderer.matrixForElement(sharpKeyName).mapRect(m_octaveRenderer.boundsOnElement(sharpKeyName));
     }
   }
 


### PR DESCRIPTION
Makes the types of the lookup tables and widget arrays strongly typed. This also makes it a little more straightforward to dehardcode some magic values related to the array sizes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/amuse/31)
<!-- Reviewable:end -->
