### PR TITLE
ADSREditor: Use std::array for m_percentTexts

### DIFF
--- a/Editor/ADSREditor.cpp
+++ b/Editor/ADSREditor.cpp
@@ -55,8 +55,8 @@ void ADSRView::paintEvent(QPaintEvent* ev) {
   painter.setPen(QPen(QColor(127, 127, 127), penWidth));
   painter.setFont(m_gridFont);
   const qreal yIncrement = (height() - 16.0) / 10.0;
-  for (int i = 0; i < 11; ++i) {
-    const qreal thisY = i * yIncrement;
+  for (size_t i = 0; i < m_percentTexts.size(); ++i) {
+    const qreal thisY = qreal(i) * yIncrement;
     const qreal textY = thisY - (i == 0 ? 2.0 : (i == 10 ? 16.0 : 8.0));
     painter.drawStaticText(QPointF(0.0, textY), m_percentTexts[i]);
     painter.drawLine(QPointF(30.0, thisY), QPointF(width(), thisY));
@@ -212,7 +212,7 @@ void ADSRView::mouseMoveEvent(QMouseEvent* ev) {
 }
 
 ADSRView::ADSRView(QWidget* parent) : QWidget(parent) {
-  for (int i = 0; i < 11; ++i) {
+  for (size_t i = 0; i < m_percentTexts.size(); ++i) {
     m_percentTexts[i].setText(QStringLiteral("%1%").arg(100 - i * 10));
     m_percentTexts[i].setTextOption(QTextOption(Qt::AlignVCenter | Qt::AlignRight));
     m_percentTexts[i].setTextWidth(28.0);

--- a/Editor/ADSREditor.hpp
+++ b/Editor/ADSREditor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -22,7 +23,7 @@ class ADSRView : public QWidget {
   friend class ADSRControls;
   amuse::ObjToken<ProjectModel::ADSRNode> m_node;
   QFont m_gridFont;
-  QStaticText m_percentTexts[11];
+  std::array<QStaticText, 11> m_percentTexts;
   std::vector<QStaticText> m_timeTexts;
   int m_dragPoint = -1;
   uint64_t m_cycleIdx = 0;


### PR DESCRIPTION
Same behavior, but allows for stronger typing and dehardcoding of sizes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/amuse/34)
<!-- Reviewable:end -->
