### PR TITLE
AudioGroupPool: Use std::array where applicable

### DIFF
--- a/Editor/SoundMacroEditor.cpp
+++ b/Editor/SoundMacroEditor.cpp
@@ -239,14 +239,15 @@ CommandWidget::CommandWidget(QWidget* parent, amuse::SoundMacro::ICmd* cmd, amus
           break;
         }
         case amuse::SoundMacro::CmdIntrospection::Field::Type::Choice: {
-          FieldComboBox* cb = new FieldComboBox(this);
+          auto* const cb = new FieldComboBox(this);
           cb->setFixedHeight(30);
           cb->setProperty("fieldIndex", f);
           cb->setProperty("fieldName", fieldName);
-          for (int j = 0; j < 4; ++j) {
-            if (field.m_choices[j].empty())
+          for (const auto choice : field.m_choices) {
+            if (choice.empty()) {
               break;
-            cb->addItem(tr(field.m_choices[j].data()));
+            }
+            cb->addItem(tr(choice.data()));
           }
           cb->setCurrentIndex(int(amuse::AccessField<int8_t>(m_cmd, field)));
           connect(cb, qOverload<int>(&FieldComboBox::currentIndexChanged), this, &CommandWidget::numChanged);

--- a/include/amuse/AudioGroupPool.hpp
+++ b/include/amuse/AudioGroupPool.hpp
@@ -150,12 +150,12 @@ struct SoundMacro {
       size_t m_offset;
       std::string_view m_name;
       int64_t m_min, m_max, m_default;
-      std::string_view m_choices[4];
+      std::array<std::string_view, 4> m_choices;
     };
     CmdType m_tp;
     std::string_view m_name;
     std::string_view m_description;
-    Field m_fields[7];
+    std::array<Field, 7> m_fields;
   };
 
   /** Base command interface. All versions of MusyX encode little-endian parameters */

--- a/lib/AudioGroupPool.cpp
+++ b/lib/AudioGroupPool.cpp
@@ -37,41 +37,42 @@ struct MakeDefaultCmdOp {
   static std::unique_ptr<SoundMacro::ICmd> Do(R& r) {
     std::unique_ptr<SoundMacro::ICmd> ret = std::make_unique<Tp>();
     if (const SoundMacro::CmdIntrospection* introspection = SoundMacro::GetCmdIntrospection(r)) {
-      for (int f = 0; f < 7; ++f) {
-        const amuse::SoundMacro::CmdIntrospection::Field& field = introspection->m_fields[f];
-        if (!field.m_name.empty()) {
-          switch (field.m_tp) {
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::Bool:
-            AccessField<bool>(ret.get(), field) = bool(field.m_default);
-            break;
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::Int8:
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::Choice:
-            AccessField<int8_t>(ret.get(), field) = int8_t(field.m_default);
-            break;
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::UInt8:
-            AccessField<uint8_t>(ret.get(), field) = uint8_t(field.m_default);
-            break;
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::Int16:
-            AccessField<int16_t>(ret.get(), field) = int16_t(field.m_default);
-            break;
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::UInt16:
-            AccessField<uint16_t>(ret.get(), field) = uint16_t(field.m_default);
-            break;
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::Int32:
-            AccessField<int32_t>(ret.get(), field) = int32_t(field.m_default);
-            break;
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::UInt32:
-            AccessField<uint32_t>(ret.get(), field) = uint32_t(field.m_default);
-            break;
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::SoundMacroId:
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::SoundMacroStep:
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::TableId:
-          case amuse::SoundMacro::CmdIntrospection::Field::Type::SampleId:
-            AccessField<SoundMacroIdDNA<athena::Endian::Little>>(ret.get(), field).id = uint16_t(field.m_default);
-            break;
-          default:
-            break;
-          }
+      for (const auto& field : introspection->m_fields) {
+        if (field.m_name.empty()) {
+          continue;
+        }
+
+        switch (field.m_tp) {
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::Bool:
+          AccessField<bool>(ret.get(), field) = bool(field.m_default);
+          break;
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::Int8:
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::Choice:
+          AccessField<int8_t>(ret.get(), field) = int8_t(field.m_default);
+          break;
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::UInt8:
+          AccessField<uint8_t>(ret.get(), field) = uint8_t(field.m_default);
+          break;
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::Int16:
+          AccessField<int16_t>(ret.get(), field) = int16_t(field.m_default);
+          break;
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::UInt16:
+          AccessField<uint16_t>(ret.get(), field) = uint16_t(field.m_default);
+          break;
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::Int32:
+          AccessField<int32_t>(ret.get(), field) = int32_t(field.m_default);
+          break;
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::UInt32:
+          AccessField<uint32_t>(ret.get(), field) = uint32_t(field.m_default);
+          break;
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::SoundMacroId:
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::SoundMacroStep:
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::TableId:
+        case amuse::SoundMacro::CmdIntrospection::Field::Type::SampleId:
+          AccessField<SoundMacroIdDNA<athena::Endian::Little>>(ret.get(), field).id = uint16_t(field.m_default);
+          break;
+        default:
+          break;
         }
       }
     }


### PR DESCRIPTION
Makes the array types strongly-typed and also allows for size querying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/amuse/43)
<!-- Reviewable:end -->
