### PR TITLE
replaced pushd and popd in standalone_bootstrap.sh

### DIFF
--- a/standalone_bootstrap.sh
+++ b/standalone_bootstrap.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 git clone https://github.com/AxioDL/boo.git
-pushd boo
+cd boo
 git submodule update --recursive --init
-popd
+cd ..
 
 git clone https://github.com/libAthena/athena.git
-pushd athena
+cd athena
 git submodule update --recursive --init
-popd
+cd ..
 


### PR DESCRIPTION
pushd and popd coused the following errors on Ubuntu 21.04:

- ./standalone_bootstrap.sh: 3: pushd: not found
- ./standalone_bootstrap.sh: 5: popd: not found
- ./standalone_bootstrap.sh: 8: pushd: not found
- ./standalone_bootstrap.sh: 10: popd: not found

Therefore I replaced them with cd